### PR TITLE
feat: add support for Linux (nixos).

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,61 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1778430510,
+        "narHash": "sha256-Ti+ZBvW6yrWWAg2szExVTwCd4qOJ3KlVr1tFHfyfi8Q=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "8fd9daa3db09ced9700431c5b7ad0e8ba199b575",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-25.11",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -37,6 +37,12 @@
             at-spi2-atk
             at-spi2-core
 
+            # GStreamer — required by WebKit2GTK for media/video support
+            gst_all_1.gstreamer
+            gst_all_1.gst-plugins-base   # provides appsink
+            gst_all_1.gst-plugins-good
+            gst_all_1.gst-plugins-bad
+
             # arboard (clipboard) — X11 backend
             libxcb
             xclip
@@ -50,8 +56,12 @@
           shellHook = ''
             export PKG_CONFIG_PATH="${pkgs.openssl.dev}/lib/pkgconfig:${pkgs.webkitgtk_4_1.dev}/lib/pkgconfig:$PKG_CONFIG_PATH"
 
-            # Workaround for WebKit rendering issues with some GPU drivers on NixOS
-            export WEBKIT_DISABLE_COMPOSITING_MODE=1
+            # GStreamer plugin path so WebKit2GTK can find appsink and friends
+            export GST_PLUGIN_SYSTEM_PATH="${pkgs.gst_all_1.gstreamer.out}/lib/gstreamer-1.0:${pkgs.gst_all_1.gst-plugins-base}/lib/gstreamer-1.0:${pkgs.gst_all_1.gst-plugins-good}/lib/gstreamer-1.0:${pkgs.gst_all_1.gst-plugins-bad}/lib/gstreamer-1.0"
+
+            # Force XWayland — WebKit2GTK's native Wayland/DMABuf renderer is broken on NixOS
+            export GDK_BACKEND=x11
+            export WEBKIT_DISABLE_DMABUF_RENDERER=1
 
             # GIO modules path so glib-networking (TLS) is found by WebKit at runtime
             export GIO_MODULE_DIR="${pkgs.glib-networking}/lib/gio/modules"

--- a/flake.nix
+++ b/flake.nix
@@ -10,7 +10,29 @@
     flake-utils.lib.eachDefaultSystem (system:
       let
         pkgs = nixpkgs.legacyPackages.${system};
+
+        # Runtime env vars needed by the binary (same as devShell)
+        gstPluginPath = pkgs.lib.concatStringsSep ":" [
+          "${pkgs.gst_all_1.gstreamer.out}/lib/gstreamer-1.0"
+          "${pkgs.gst_all_1.gst-plugins-base}/lib/gstreamer-1.0"
+          "${pkgs.gst_all_1.gst-plugins-good}/lib/gstreamer-1.0"
+          "${pkgs.gst_all_1.gst-plugins-bad}/lib/gstreamer-1.0"
+        ];
       in {
+        # Install with: nix profile install path:.
+        # Requires the binary to be pre-built: pnpm tauri build
+        packages.default = pkgs.runCommand "annot" {
+          nativeBuildInputs = [ pkgs.makeWrapper ];
+          meta.mainProgram = "annot";
+        } ''
+          mkdir -p $out/bin
+          makeWrapper ${./src-tauri/target/release/annot} $out/bin/annot \
+            --set GDK_BACKEND x11 \
+            --set WEBKIT_DISABLE_DMABUF_RENDERER 1 \
+            --set GST_PLUGIN_SYSTEM_PATH "${gstPluginPath}" \
+            --set GIO_MODULE_DIR "${pkgs.glib-networking}/lib/gio/modules"
+        '';
+
         devShells.default = pkgs.mkShell {
           nativeBuildInputs = with pkgs; [
             pkg-config

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,71 @@
+{
+  description = "annot dev shell — Tauri v2 + SvelteKit on Linux";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-25.11";
+    flake-utils.url = "github:numtide/flake-utils";
+  };
+
+  outputs = { self, nixpkgs, flake-utils }:
+    flake-utils.lib.eachDefaultSystem (system:
+      let
+        pkgs = nixpkgs.legacyPackages.${system};
+      in {
+        devShells.default = pkgs.mkShell {
+          nativeBuildInputs = with pkgs; [
+            pkg-config
+            cargo
+            rustc
+            rustfmt
+            clippy
+            nodejs_22
+            pnpm
+          ];
+
+          buildInputs = with pkgs; [
+            # Tauri v2 requires WebKit2GTK 4.1 (not 4.0)
+            webkitgtk_4_1
+            gtk3
+            glib
+            glib-networking   # TLS support for WebKit
+            libsoup_3
+            openssl
+            cairo
+            pango
+            gdk-pixbuf
+            librsvg
+            at-spi2-atk
+            at-spi2-core
+
+            # arboard (clipboard) — X11 backend
+            libxcb
+            xclip
+
+            # tauri-plugin-opener uses xdg-open on Linux
+            xdg-utils
+          ];
+
+          # PKG_CONFIG_PATH is usually set automatically by mkShell for buildInputs,
+          # but openssl sometimes needs a nudge.
+          shellHook = ''
+            export PKG_CONFIG_PATH="${pkgs.openssl.dev}/lib/pkgconfig:${pkgs.webkitgtk_4_1.dev}/lib/pkgconfig:$PKG_CONFIG_PATH"
+
+            # Workaround for WebKit rendering issues with some GPU drivers on NixOS
+            export WEBKIT_DISABLE_COMPOSITING_MODE=1
+
+            # GIO modules path so glib-networking (TLS) is found by WebKit at runtime
+            export GIO_MODULE_DIR="${pkgs.glib-networking}/lib/gio/modules"
+
+            # pnpm@8.10.2 is pinned in package.json via corepack.
+            # nixpkgs ships a different pnpm version — disable strict corepack enforcement.
+            export COREPACK_ENABLE_STRICT=0
+
+            echo "annot dev shell ready"
+            echo "  pnpm install     — install JS deps"
+            echo "  pnpm tauri dev   — start dev server + Tauri window"
+            echo "  pnpm tauri build — production build"
+          '';
+        };
+      }
+    );
+}

--- a/src-tauri/src/excalidraw_window.rs
+++ b/src-tauri/src/excalidraw_window.rs
@@ -148,13 +148,14 @@ pub fn open_excalidraw_window(
     .title("Excalidraw")
     .inner_size(width, height)
     .min_inner_size(600.0, 400.0)
-    .visible(false)
-    .title_bar_style(tauri::TitleBarStyle::Overlay)
-    .hidden_title(true);
+    .visible(false);
 
     #[cfg(target_os = "macos")]
     {
-        builder = builder.traffic_light_position(tauri::LogicalPosition::new(12.0, 22.0));
+        builder = builder
+            .title_bar_style(tauri::TitleBarStyle::Overlay)
+            .hidden_title(true)
+            .traffic_light_position(tauri::LogicalPosition::new(12.0, 22.0));
     }
 
     let new_window = builder

--- a/src-tauri/src/excalidraw_window.rs
+++ b/src-tauri/src/excalidraw_window.rs
@@ -140,23 +140,23 @@ pub fn open_excalidraw_window(
     }
 
     // Create new window (hidden until frontend renders)
-    let mut builder = WebviewWindowBuilder::new(
-        &app,
-        &label,
-        tauri::WebviewUrl::App("excalidraw".into()),
-    )
-    .title("Excalidraw")
-    .inner_size(width, height)
-    .min_inner_size(600.0, 400.0)
-    .visible(false);
-
-    #[cfg(target_os = "macos")]
-    {
-        builder = builder
+    let builder = {
+        let b = WebviewWindowBuilder::new(
+            &app,
+            &label,
+            tauri::WebviewUrl::App("excalidraw".into()),
+        )
+        .title("Excalidraw")
+        .inner_size(width, height)
+        .min_inner_size(600.0, 400.0)
+        .visible(false);
+        #[cfg(target_os = "macos")]
+        let b = b
             .title_bar_style(tauri::TitleBarStyle::Overlay)
             .hidden_title(true)
             .traffic_light_position(tauri::LogicalPosition::new(12.0, 22.0));
-    }
+        b
+    };
 
     let new_window = builder
         .build()

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -134,22 +134,22 @@ pub fn run(state: AppState, context: tauri::Context, json_output: bool) {
         .invoke_handler(all_commands!())
         .setup(|app| {
             // Create window programmatically (not from config, for MCP compatibility)
-            let mut builder = WebviewWindowBuilder::new(
-                app,
-                "main",
-                tauri::WebviewUrl::App("index.html".into()),
-            )
-            .title("annot")
-            .inner_size(1000.0, 700.0)
-            .visible(false); // Will be shown after content loads
-
-            #[cfg(target_os = "macos")]
-            {
-                builder = builder
+            let builder = {
+                let b = WebviewWindowBuilder::new(
+                    app,
+                    "main",
+                    tauri::WebviewUrl::App("index.html".into()),
+                )
+                .title("annot")
+                .inner_size(1000.0, 700.0)
+                .visible(false); // Will be shown after content loads
+                #[cfg(target_os = "macos")]
+                let b = b
                     .title_bar_style(tauri::TitleBarStyle::Overlay)
                     .hidden_title(true)
                     .traffic_light_position(tauri::LogicalPosition::new(12.0, 22.0));
-            }
+                b
+            };
 
             let window = builder.build()?;
 

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -141,13 +141,14 @@ pub fn run(state: AppState, context: tauri::Context, json_output: bool) {
             )
             .title("annot")
             .inner_size(1000.0, 700.0)
-            .visible(false) // Will be shown after content loads
-            .title_bar_style(tauri::TitleBarStyle::Overlay)
-            .hidden_title(true);
+            .visible(false); // Will be shown after content loads
 
             #[cfg(target_os = "macos")]
             {
-                builder = builder.traffic_light_position(tauri::LogicalPosition::new(12.0, 22.0));
+                builder = builder
+                    .title_bar_style(tauri::TitleBarStyle::Overlay)
+                    .hidden_title(true)
+                    .traffic_light_position(tauri::LogicalPosition::new(12.0, 22.0));
             }
 
             let window = builder.build()?;

--- a/src-tauri/src/mcp/mod.rs
+++ b/src-tauri/src/mcp/mod.rs
@@ -415,13 +415,14 @@ fn run_session_with_state(
     let mut builder = WebviewWindowBuilder::new(app_handle, &window_label, tauri::WebviewUrl::App("index.html".into()))
         .title("annot")
         .inner_size(1000.0, 700.0)
-        .visible(false) // Will be shown after content loads
-        .title_bar_style(tauri::TitleBarStyle::Overlay)
-        .hidden_title(true);
+        .visible(false); // Will be shown after content loads
 
     #[cfg(target_os = "macos")]
     {
-        builder = builder.traffic_light_position(tauri::LogicalPosition::new(12.0, 22.0));
+        builder = builder
+            .title_bar_style(tauri::TitleBarStyle::Overlay)
+            .hidden_title(true)
+            .traffic_light_position(tauri::LogicalPosition::new(12.0, 22.0));
     }
 
     let window = builder

--- a/src-tauri/src/mcp/mod.rs
+++ b/src-tauri/src/mcp/mod.rs
@@ -412,18 +412,18 @@ fn run_session_with_state(
         *slot.lock() = Some(review);
     }
 
-    let mut builder = WebviewWindowBuilder::new(app_handle, &window_label, tauri::WebviewUrl::App("index.html".into()))
-        .title("annot")
-        .inner_size(1000.0, 700.0)
-        .visible(false); // Will be shown after content loads
-
-    #[cfg(target_os = "macos")]
-    {
-        builder = builder
+    let builder = {
+        let b = WebviewWindowBuilder::new(app_handle, &window_label, tauri::WebviewUrl::App("index.html".into()))
+            .title("annot")
+            .inner_size(1000.0, 700.0)
+            .visible(false); // Will be shown after content loads
+        #[cfg(target_os = "macos")]
+        let b = b
             .title_bar_style(tauri::TitleBarStyle::Overlay)
             .hidden_title(true)
             .traffic_light_position(tauri::LogicalPosition::new(12.0, 22.0));
-    }
+        b
+    };
 
     let window = builder
         .build()

--- a/src-tauri/src/mermaid_window.rs
+++ b/src-tauri/src/mermaid_window.rs
@@ -92,13 +92,14 @@ pub fn open_mermaid_window(
     .title(format!("{}:{}-{}", filename, start_line, end_line))
     .inner_size(600.0, 500.0)
     .min_inner_size(300.0, 200.0)
-    .visible(false)
-    .title_bar_style(tauri::TitleBarStyle::Overlay)
-    .hidden_title(true);
+    .visible(false);
 
     #[cfg(target_os = "macos")]
     {
-        builder = builder.traffic_light_position(tauri::LogicalPosition::new(12.0, 22.0));
+        builder = builder
+            .title_bar_style(tauri::TitleBarStyle::Overlay)
+            .hidden_title(true)
+            .traffic_light_position(tauri::LogicalPosition::new(12.0, 22.0));
     }
 
     let new_window = builder

--- a/src-tauri/src/mermaid_window.rs
+++ b/src-tauri/src/mermaid_window.rs
@@ -84,23 +84,23 @@ pub fn open_mermaid_window(
     // Create new window (hidden until frontend sizes it)
     // Note: We don't use .parent() because macOS child windows can't be
     // dragged to other displays. Instead, mermaid windows are independent.
-    let mut builder = WebviewWindowBuilder::new(
-        &app,
-        &label,
-        tauri::WebviewUrl::App("mermaid".into()),
-    )
-    .title(format!("{}:{}-{}", filename, start_line, end_line))
-    .inner_size(600.0, 500.0)
-    .min_inner_size(300.0, 200.0)
-    .visible(false);
-
-    #[cfg(target_os = "macos")]
-    {
-        builder = builder
+    let builder = {
+        let b = WebviewWindowBuilder::new(
+            &app,
+            &label,
+            tauri::WebviewUrl::App("mermaid".into()),
+        )
+        .title(format!("{}:{}-{}", filename, start_line, end_line))
+        .inner_size(600.0, 500.0)
+        .min_inner_size(300.0, 200.0)
+        .visible(false);
+        #[cfg(target_os = "macos")]
+        let b = b
             .title_bar_style(tauri::TitleBarStyle::Overlay)
             .hidden_title(true)
             .traffic_light_position(tauri::LogicalPosition::new(12.0, 22.0));
-    }
+        b
+    };
 
     let new_window = builder
         .build()

--- a/src-tauri/src/window_state.rs
+++ b/src-tauri/src/window_state.rs
@@ -122,6 +122,7 @@ fn display_config_id(app: &AppHandle) -> Option<String> {
 pub fn save_window_state(window: &WebviewWindow, window_type: WindowType) -> Result<(), String> {
     let pos = window.outer_position().map_err(|e| e.to_string())?;
     let size = window.inner_size().map_err(|e| e.to_string())?;
+    #[cfg(target_os = "macos")]
     let scale = window.scale_factor().unwrap_or(1.0);
 
     // macOS uses logical coordinates for window positioning

--- a/src/lib/AnnotationEditor.svelte
+++ b/src/lib/AnnotationEditor.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import { onMount, onDestroy } from 'svelte';
+  import { keys } from '$lib/keys';
   import type { JSONContent } from '@tiptap/core';
   import { invoke } from '@tauri-apps/api/core';
   import { listen, type UnlistenFn } from '@tauri-apps/api/event';
@@ -505,7 +506,7 @@
       <span class="kbd-hint"><kbd>#</kbd> tags</span>
       <span class="kbd-hint"><kbd>@</kbd> refs</span>
       <span class="kbd-hint"><kbd>/</kbd> commands</span>
-      <span class="kbd-hint"><kbd>⌘↵</kbd> done</span>
+      <span class="kbd-hint"><kbd>{keys.cmd}+↵</kbd> done</span>
       <span class="kbd-hint"><kbd>Esc</kbd> cancel</span>
     </div>
   {/if}

--- a/src/lib/CommandPalette/CommandPalette.svelte
+++ b/src/lib/CommandPalette/CommandPalette.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import { onMount, setContext } from 'svelte';
+  import { keys } from '$lib/keys';
   import { invoke } from '@tauri-apps/api/core';
   import { openUrl } from '@tauri-apps/plugin-opener';
   import { reduce, computeItemList } from './engine/reducer';
@@ -541,7 +542,7 @@
       }
       // Add Cmd-D delete hint if namespace allows deletion
       if (canDelete(machineState.namespace)) {
-        hints.push({ key: '⌘D', label: 'delete' });
+        hints.push({ key: `${keys.cmd}+D`, label: 'delete' });
       }
       hints.push({ key: '↵', label: 'select' });
       hints.push({ key: 'Esc', label: 'back' });
@@ -550,25 +551,25 @@
     if (machineState.type === 'ITEM_REORDER') {
       return [
         { key: '↑↓', label: 'nav' },
-        { key: '⌘⌥↑↓', label: 'move' },
+        { key: `${keys.cmd}+${keys.alt}+↑↓`, label: 'move' },
         { key: '↵', label: 'save' },
       ];
     }
     if (machineState.type === 'EDIT_FORM') {
-      const hints = [{ key: '⌘↵', label: 'save' }];
+      const hints = [{ key: `${keys.cmd}+↵`, label: 'save' }];
       // Only show Tab hint if there are multiple fields to navigate
       if (machineState.namespace.fields.length > 1) {
         hints.push({ key: 'Tab', label: 'next field' });
       }
       // Add Cmd-D delete hint if item can be deleted
       if (canDelete(machineState.namespace) && isItemEditable(machineState.item)) {
-        hints.push({ key: '⌘D', label: 'delete' });
+        hints.push({ key: `${keys.cmd}+D`, label: 'delete' });
       }
       hints.push({ key: 'Esc', label: 'cancel' });
       return hints;
     }
     if (machineState.type === 'CREATE_FORM') {
-      const hints = [{ key: '⌘↵', label: 'save' }];
+      const hints = [{ key: `${keys.cmd}+↵`, label: 'save' }];
       // Only show Tab hint if there are multiple fields to navigate
       if (machineState.namespace.fields.length > 1) {
         hints.push({ key: 'Tab', label: 'next field' });

--- a/src/lib/HelpOverlay.svelte
+++ b/src/lib/HelpOverlay.svelte
@@ -1,4 +1,6 @@
 <script lang="ts">
+  import { keys } from '$lib/keys';
+
   interface Props {
     onClose: () => void;
   }
@@ -23,7 +25,7 @@
       category: 'Annotation',
       items: [
         { keys: ['c'], description: 'Comment hovered line' },
-        { keys: ['⇧', 'C'], description: 'Open session editor (global comment)' },
+        { keys: [keys.shift, 'C'], description: 'Open session editor (global comment)' },
       ]
     },
     {
@@ -38,7 +40,7 @@
       category: 'Bookmarks',
       items: [
         { keys: ['b'], description: 'Bookmark hovered line or selection' },
-        { keys: ['⇧', 'B'], description: 'Bookmark entire session' },
+        { keys: [keys.shift, 'B'], description: 'Bookmark entire session' },
         { keys: ['e'], description: 'Edit last created bookmark' },
       ]
     },
@@ -57,40 +59,40 @@
         { keys: ['<'], description: 'Lean in (direction)' },
         { keys: ['>'], description: 'Move away (direction)' },
         { keys: ['r'], description: 'Toggle reframe (direction)' },
-        { keys: ['⌘', '↵'], description: 'Save terraform' },
-        { keys: ['⌘', 'D'], description: 'Delete terraform' },
+        { keys: [keys.cmd, '↵'], description: 'Save terraform' },
+        { keys: [keys.cmd, 'D'], description: 'Delete terraform' },
       ]
     },
     {
       category: 'Navigation',
       items: [
-        { keys: ['⌘', 'F'], description: 'Search content' },
+        { keys: [keys.cmd, 'F'], description: 'Search content' },
         { keys: [':'], description: 'Open command palette' },
         { keys: ['Tab'], description: 'Cycle exit mode forward' },
-        { keys: ['⇧', 'Tab'], description: 'Cycle exit mode backward' },
-        { keys: ['⌥', 'Tab'], description: 'Open exit mode picker' },
+        { keys: [keys.shift, 'Tab'], description: 'Cycle exit mode backward' },
+        { keys: [keys.alt, 'Tab'], description: 'Open exit mode picker' },
       ]
     },
     {
       category: 'Selection',
       items: [
-        { keys: ['⇧', 'drag'], description: 'Select line range' },
+        { keys: [keys.shift, 'drag'], description: 'Select line range' },
         { keys: ['Esc'], description: 'Cancel pending choice' },
       ]
     },
     {
       category: 'View',
       items: [
-        { keys: ['⌘', '+'], description: 'Zoom in' },
-        { keys: ['⌘', '-'], description: 'Zoom out' },
-        { keys: ['⌘', '0'], description: 'Reset zoom' },
+        { keys: [keys.cmd, '+'], description: 'Zoom in' },
+        { keys: [keys.cmd, '-'], description: 'Zoom out' },
+        { keys: [keys.cmd, '0'], description: 'Reset zoom' },
       ]
     },
     {
       category: 'File',
       items: [
-        { keys: ['⌘', 'S'], description: 'Save to file' },
-        { keys: ['⌘', 'W'], description: 'Save and close' },
+        { keys: [keys.cmd, 'S'], description: 'Save to file' },
+        { keys: [keys.cmd, 'W'], description: 'Save and close' },
       ]
     },
   ];

--- a/src/lib/components/StatusBar.svelte
+++ b/src/lib/components/StatusBar.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import { getAnnotContext } from '$lib/context';
+  import { keys } from '$lib/keys';
 
   const ctx = getAnnotContext();
 
@@ -28,9 +29,9 @@
   </div>
   <div class="status-bar-right">
     <span class="kbd-hint"><kbd>:</kbd> command palette</span>
-    <span class="kbd-hint"><kbd>c</kbd> <kbd>⇧c</kbd> annotate</span>
-    <span class="kbd-hint"><kbd>b</kbd> <kbd>⇧b</kbd> bookmark</span>
+    <span class="kbd-hint"><kbd>c</kbd> <kbd>{keys.shift}+C</kbd> annotate</span>
+    <span class="kbd-hint"><kbd>b</kbd> <kbd>{keys.shift}+B</kbd> bookmark</span>
     <span class="kbd-hint"><kbd>?</kbd> help</span>
-    <span class="kbd-hint"><kbd>⌘w</kbd> save and close</span>
+    <span class="kbd-hint"><kbd>{keys.cmd}+W</kbd> save and close</span>
   </div>
 </footer>

--- a/src/lib/components/TerraformPalette.svelte
+++ b/src/lib/components/TerraformPalette.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import { useTerraform, FORM_LABELS } from '$lib/composables/useTerraform.svelte';
+  import { keys } from '$lib/keys';
   import type { TerraformRegion, FormType } from '$lib/types';
   import { FORM_TYPES, INTENSITY_LEVELS, emptyTransformIntent } from '$lib/types';
   import DiscreteSlider from './DiscreteSlider.svelte';
@@ -528,9 +529,9 @@
   {/if}
 
   <div class="terraform-hints">
-    <span class="terraform-hint"><kbd>⌘↵</kbd> save</span>
+    <span class="terraform-hint"><kbd>{keys.cmd}+↵</kbd> save</span>
     {#if initialRegion}
-      <span class="terraform-hint"><kbd>⌘D</kbd> delete</span>
+      <span class="terraform-hint"><kbd>{keys.cmd}+D</kbd> delete</span>
     {/if}
     <span class="terraform-hint"><kbd>esc</kbd> cancel</span>
   </div>

--- a/src/lib/composables/useKeyboard.svelte.ts
+++ b/src/lib/composables/useKeyboard.svelte.ts
@@ -9,6 +9,7 @@ export interface KeyboardHandlers {
   onOpenCommandPalette?: () => void;
   onOpenCommandPaletteWithNamespace?: (namespace: 'exit-modes') => void;
   onOpenSaveModal?: () => void;
+  onCloseWindow?: () => void;
   onOpenSearch?: () => void;
   onOpenHelp?: () => void;
   onCreateSessionBookmark?: () => void;
@@ -126,8 +127,8 @@ export function useKeyboard(handlers: KeyboardHandlers, state: KeyboardState) {
       }
     }
 
-    // Shift+C for global/session comment
-    if (e.key === 'C' && !e.metaKey && !e.ctrlKey && !state.isEditorActive()) {
+    // 'g' or Shift+C for global/session comment
+    if ((e.key === 'g' || e.key === 'C') && !e.metaKey && !e.ctrlKey && !state.isEditorActive()) {
       if (isInEditorOrInput()) return;
       e.preventDefault();
       handlers.onOpenSessionEditor?.();
@@ -149,6 +150,13 @@ export function useKeyboard(handlers: KeyboardHandlers, state: KeyboardState) {
       if (e.metaKey || e.ctrlKey || e.altKey) return;
       e.preventDefault();
       handlers.onOpenHelp?.();
+      return;
+    }
+
+    // Cmd+W / Ctrl+W to close window (on macOS this is handled natively; on Linux it must be explicit)
+    if (e.key === 'w' && (e.metaKey || e.ctrlKey)) {
+      e.preventDefault();
+      handlers.onCloseWindow?.();
       return;
     }
 

--- a/src/lib/keys.ts
+++ b/src/lib/keys.ts
@@ -1,0 +1,7 @@
+declare const __IS_MACOS__: boolean;
+
+export const keys = {
+  cmd:   __IS_MACOS__ ? '⌘'  : 'Ctrl',
+  alt:   __IS_MACOS__ ? '⌥'  : 'Alt',
+  shift: __IS_MACOS__ ? '⇧'  : 'Shift',
+};

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -683,6 +683,7 @@
         overlay.openCommandPalette(namespace);
       },
       onOpenSaveModal: openSaveModal,
+      onCloseWindow: () => getCurrentWindow().close(),
       onOpenSearch: () => search.open(),
       onOpenHelp: () => overlay.openHelp(),
       onCreateSessionBookmark: handleToggleBookmark,

--- a/src/routes/excalidraw/+page.svelte
+++ b/src/routes/excalidraw/+page.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import { onMount, onDestroy } from 'svelte';
+  import { keys } from '$lib/keys';
   import { invoke } from '@tauri-apps/api/core';
   import { getCurrentWindow } from '@tauri-apps/api/window';
   import type { ExcalidrawHandle } from '$lib/excalidraw-loader';
@@ -248,7 +249,7 @@
     <div class="status-bar-left"></div>
     <div class="status-bar-right">
       <span class="kbd-hint"><kbd>Esc</kbd> dismiss</span>
-      <span class="kbd-hint"><kbd>⌘W</kbd> save and close</span>
+      <span class="kbd-hint"><kbd>{keys.cmd}+W</kbd> save and close</span>
     </div>
   </footer>
 </div>

--- a/vite.config.js
+++ b/vite.config.js
@@ -4,6 +4,8 @@ import { svelteTesting } from "@testing-library/svelte/vite";
 
 // @ts-expect-error process is a nodejs global
 const host = process.env.TAURI_DEV_HOST;
+// @ts-expect-error process is a nodejs global
+const isMacos = process.platform === 'darwin';
 
 // Custom logger to filter out Svelte 5 @__PURE__ annotation warnings
 const logger = createLogger();
@@ -20,6 +22,9 @@ logger.warn = (msg, options) => {
 export default defineConfig(async () => ({
   customLogger: logger,
   plugins: [sveltekit(), svelteTesting()],
+  define: {
+    __IS_MACOS__: JSON.stringify(isMacos),
+  },
 
   test: {
     environment: "jsdom",


### PR DESCRIPTION
This pull request introduces several improvements focused on cross-platform keyboard shortcut handling, developer experience on Linux, and minor behavioral fixes for window creation. The main highlights are the addition of a `keys` utility for platform-aware shortcut display, consistent usage of this utility throughout the UI, and the introduction of a Nix flake for streamlined Linux development. There are also minor fixes to window builder logic and keyboard event handling.

**Keyboard shortcut handling and UI consistency:**

* Added a new `keys` utility (`src/lib/keys.ts`) that provides platform-aware key labels (`⌘`/`Ctrl`, `⌥`/`Alt`, `⇧`/`Shift`) for use across the UI, determined at build time via the `__IS_MACOS__` constant.
* Updated all UI components (`StatusBar.svelte`, `HelpOverlay.svelte`, `CommandPalette.svelte`, `AnnotationEditor.svelte`, `TerraformPalette.svelte`, `excalidraw/+page.svelte`) to use the new `keys` utility for rendering keyboard shortcut hints, ensuring consistency and correct labeling on both macOS and Linux/Windows. [[1]](diffhunk://#diff-f4a2e4cad0c848555f51ffbc7ad6620d95ce841aed172f5cd3684249024cab04R3) [[2]](diffhunk://#diff-f4a2e4cad0c848555f51ffbc7ad6620d95ce841aed172f5cd3684249024cab04L31-R35) [[3]](diffhunk://#diff-f712b8e25adf20b64fca6c8510299b946da054048a4d53a1238bf54d7d8f1fbbR2-R3) [[4]](diffhunk://#diff-f712b8e25adf20b64fca6c8510299b946da054048a4d53a1238bf54d7d8f1fbbL26-R28) [[5]](diffhunk://#diff-f712b8e25adf20b64fca6c8510299b946da054048a4d53a1238bf54d7d8f1fbbL41-R43) [[6]](diffhunk://#diff-f712b8e25adf20b64fca6c8510299b946da054048a4d53a1238bf54d7d8f1fbbL60-R95) [[7]](diffhunk://#diff-582aa326d31905bded882e335d7e5d296b0d613e3db4e4047b6b9e23db9a7e86R3) [[8]](diffhunk://#diff-582aa326d31905bded882e335d7e5d296b0d613e3db4e4047b6b9e23db9a7e86L544-R545) [[9]](diffhunk://#diff-582aa326d31905bded882e335d7e5d296b0d613e3db4e4047b6b9e23db9a7e86L553-R572) [[10]](diffhunk://#diff-0f46b97ddb0be2dc176bf13d262029fadf4f83f566adcf0fe6bbefec56c4b8cbR3) [[11]](diffhunk://#diff-0f46b97ddb0be2dc176bf13d262029fadf4f83f566adcf0fe6bbefec56c4b8cbL508-R509) [[12]](diffhunk://#diff-db0d466b6e7a987255f994654c9a8791c8307cca53616992612444ac1133f30bR3) [[13]](diffhunk://#diff-db0d466b6e7a987255f994654c9a8791c8307cca53616992612444ac1133f30bL531-R534) [[14]](diffhunk://#diff-85819649a299be0b721d3492f41981364c6fe55772882ae653cd27856090c2c0R3) [[15]](diffhunk://#diff-85819649a299be0b721d3492f41981364c6fe55772882ae653cd27856090c2c0L251-R252)

**Keyboard event handling improvements:**

* Added a new handler (`onCloseWindow`) to the keyboard handler interface and implementation, allowing explicit handling of `Cmd+W`/`Ctrl+W` to close the window on Linux (where it is not handled natively), and mapped this handler in the main page logic. Also, added support for `g` as a shortcut for opening the session editor. [[1]](diffhunk://#diff-39780a3b41559694fcb950c7ed5f77afade8d5419280fe41d6435003bdaa56b7R12) [[2]](diffhunk://#diff-39780a3b41559694fcb950c7ed5f77afade8d5419280fe41d6435003bdaa56b7L129-R131) [[3]](diffhunk://#diff-39780a3b41559694fcb950c7ed5f77afade8d5419280fe41d6435003bdaa56b7R156-R162) [[4]](diffhunk://#diff-1e1270da740e81dd13f8a65057582b0fce8a5fb3817ef913f3e90d7f82c4e9dfR686)

**Developer experience (Nix and Linux support):**

* Added a new `flake.nix` file providing a Nix flake for Linux development, including a dev shell with all dependencies for Tauri v2 and SvelteKit, and a package for installing the prebuilt Tauri binary with correct environment variables.

**Window builder logic fixes:**

* Refactored Tauri window builder logic in multiple Rust files to only set `title_bar_style` and `hidden_title` on macOS, fixing incorrect UI on Linux/Windows by moving these calls inside the `#[cfg(target_os = "macos")]` block. [[1]](diffhunk://#diff-8e2f8665921d382595b253bb6b3451b349c2a369396ba60633d5cbcc9337274bL151-R158) [[2]](diffhunk://#diff-eabcebd0ae5c9b77a5247e1bdbdb88b1869fc0c932d0ef0cf2ecf9ee5221be7cL144-R151) [[3]](diffhunk://#diff-608f9a440bb17c0fe29e5dda50b72469c7c8a6c3c809f97ed906a1f2040f6180L418-R425) [[4]](diffhunk://#diff-ec0420a217fe2c0212572762a2482bf025e9dc3289d8c5c4ed29ab8e511fea15L95-R102)

**Build configuration:**

* Added detection of the current platform (`isMacos`) in `vite.config.js` for build-time platform-specific logic.

These changes together improve the cross-platform user experience, developer onboarding (especially on NixOS/Linux), and maintain a consistent and correct UI for keyboard shortcuts and window decorations.