### PR TITLE
fix: update the annot version to 0.8.0.

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -43,7 +43,7 @@ dependencies = [
 
 [[package]]
 name = "annot"
-version = "0.7.1"
+version = "0.8.0"
 dependencies = [
  "arboard",
  "base64 0.22.1",


### PR DESCRIPTION
For some reason the `Cargo.lock` points to `0.7.1` , make it point to the latest version `0.8.0`.