### PR TITLE
docs: add Linux/NixOS support documentation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -34,6 +34,29 @@ pnpm check
 
 **Dev vs Build gotcha**: `cargo build` produces a binary that connects to localhost:1420. For standalone testing, use `pnpm tauri build --debug`.
 
+## NixOS / Linux
+
+A `flake.nix` is provided. Enter the dev shell before running any build commands:
+
+```bash
+nix develop          # sets up cargo, pnpm, webkitgtk, GStreamer, pkg-config, etc.
+```
+
+The shell hook also exports `GDK_BACKEND=x11` and `WEBKIT_DISABLE_DMABUF_RENDERER=1`
+so the dev server renders correctly under Wayland.
+
+To install the binary into your Nix profile (wraps it with the required env vars):
+
+```bash
+nix profile install path:.   # run outside nix develop
+```
+
+MCP registration on Linux (settings.json mcpServers is not supported — use CLI):
+
+```bash
+claude mcp add --scope user annot annot mcp
+```
+
 ## Architecture
 
 **Backend** (`src-tauri/src/`):

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -34,7 +34,40 @@ pnpm check
 
 **Dev vs Build gotcha**: `cargo build` produces a binary that connects to localhost:1420. For standalone testing, use `pnpm tauri build --debug`.
 
-## NixOS / Linux
+## Ubuntu / Linux
+
+Install system dependencies before running any build commands:
+
+```bash
+sudo apt-get update
+sudo apt-get install -y \
+  libwebkit2gtk-4.1-dev \
+  build-essential \
+  file \
+  libxdo-dev \
+  libssl-dev \
+  libayatana-appindicator3-dev \
+  librsvg2-dev \
+  libgstreamer1.0-dev \
+  libgstreamer-plugins-base1.0-dev \
+  gstreamer1.0-plugins-good \
+  gstreamer1.0-plugins-bad \
+  libgstreamer-plugins-bad1.0-dev
+```
+
+Then install Rust (if not already present):
+
+```bash
+curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
+```
+
+MCP registration on Linux (`mcpServers` in settings.json is not supported — use CLI):
+
+```bash
+claude mcp add --scope user annot annot mcp
+```
+
+## NixOS
 
 A `flake.nix` is provided. Enter the dev shell before running any build commands:
 
@@ -51,11 +84,7 @@ To install the binary into your Nix profile (wraps it with the required env vars
 nix profile install path:.   # run outside nix develop
 ```
 
-MCP registration on Linux (settings.json mcpServers is not supported — use CLI):
-
-```bash
-claude mcp add --scope user annot annot mcp
-```
+MCP registration — same as Ubuntu above.
 
 ## Architecture
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 An annotation tool for human-in-the-loop AI workflows.
 
-> **Platform**: macOS only (Apple Silicon). Not tested on Linux or Windows.
+> **Platform**: macOS (Apple Silicon) and Linux (NixOS/Wayland tested). Not tested on Windows.
 
 ![annot screenshot](docs/screenshot.png)
 
@@ -14,12 +14,14 @@ annot is that moment of review. It opens a window, you shape the content with lo
 
 ## Install
 
+**macOS:**
+
 ```bash
 brew install denolehov/tap/annot
 ```
 
 <details>
-<summary>Build from source</summary>
+<summary>Build from source (macOS)</summary>
 
 ```bash
 git clone https://github.com/denolehov/annot.git && cd annot
@@ -29,11 +31,33 @@ pnpm tauri build
 
 </details>
 
+<details>
+<summary>Build from source (NixOS / Linux)</summary>
+
+```bash
+git clone https://github.com/denolehov/annot.git && cd annot
+nix develop          # enter dev shell with all build dependencies
+pnpm install
+pnpm tauri build     # binary at src-tauri/target/release/annot
+```
+
+Or install into your Nix profile (wraps the binary with required env vars):
+
+```bash
+nix profile install path:.
+```
+
+> **Wayland note**: The installed binary automatically sets `GDK_BACKEND=x11` and
+> `WEBKIT_DISABLE_DMABUF_RENDERER=1` via the Nix wrapper, which prevents broken
+> text rendering in WebKit2GTK under Wayland.
+
+</details>
+
 ## Quick start
 
 ### With Claude Code
 
-Add to your MCP settings (`~/.claude/settings.json` or project `.claude/settings.json`):
+**macOS** — add to your MCP settings (`~/.claude/settings.json` or project `.claude/settings.json`):
 
 ```json
 {
@@ -44,6 +68,12 @@ Add to your MCP settings (`~/.claude/settings.json` or project `.claude/settings
     }
   }
 }
+```
+
+**Linux** — use the CLI instead:
+
+```bash
+claude mcp add --scope user annot annot mcp
 ```
 
 Claude now has review tools (`review_file`, `review_diff`, `review_content`) and bookmark tools (`get_bookmark`, `list_bookmarks`). Ask it to review something and a window opens for your feedback.
@@ -163,8 +193,8 @@ Press `Shift+C` to add comments that apply to the entire review — framing cont
 | Tab / Shift+Tab | Cycle exit modes |
 | Alt+Tab | Exit mode picker |
 | : | Command palette |
-| Cmd+F | Search |
-| Cmd+S | Save to file |
+| Cmd+F / Ctrl+F | Search |
+| Cmd+S / Ctrl+S | Save to file |
 | ? | Help overlay |
 
 **In annotation editor:**

--- a/README.md
+++ b/README.md
@@ -32,7 +32,40 @@ pnpm tauri build
 </details>
 
 <details>
-<summary>Build from source (NixOS / Linux)</summary>
+<summary>Build from source (Ubuntu)</summary>
+
+Install system dependencies:
+
+```bash
+sudo apt-get update
+sudo apt-get install -y \
+  libwebkit2gtk-4.1-dev \
+  build-essential \
+  file \
+  libxdo-dev \
+  libssl-dev \
+  libayatana-appindicator3-dev \
+  librsvg2-dev \
+  libgstreamer1.0-dev \
+  libgstreamer-plugins-base1.0-dev \
+  gstreamer1.0-plugins-good \
+  gstreamer1.0-plugins-bad \
+  libgstreamer-plugins-bad1.0-dev
+```
+
+Install Rust, Node.js 22, and pnpm, then build:
+
+```bash
+curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
+git clone https://github.com/denolehov/annot.git && cd annot
+pnpm install
+pnpm tauri build     # binary at src-tauri/target/release/annot
+```
+
+</details>
+
+<details>
+<summary>Build from source (NixOS)</summary>
 
 ```bash
 git clone https://github.com/denolehov/annot.git && cd annot

--- a/docs/features.md
+++ b/docs/features.md
@@ -276,6 +276,8 @@ Atomic writes with file locking for concurrent safety.
 ## Platform Support
 
 Native Tauri app for:
-- macOS (traffic light positioning, overlay title bar)
-- Linux
-- Windows
+- **macOS** — overlay title bar, traffic light positioning, native Cmd+W close
+- **Linux** — tested on NixOS with Wayland (via XWayland); requires `GDK_BACKEND=x11`
+  and `WEBKIT_DISABLE_DMABUF_RENDERER=1` for correct WebKit2GTK rendering (baked into
+  the Nix-installed binary automatically)
+- Windows (untested)


### PR DESCRIPTION
This pull request adds official support and installation instructions for Linux (specifically NixOS/Wayland) alongside macOS, updates platform support documentation, and clarifies usage instructions for both platforms. The most important changes are grouped below:

**Linux/NixOS Support and Installation:**
* Added a `flake.nix` and instructions for setting up a Nix development shell, building, and installing the app on Linux/NixOS. The dev shell configures required environment variables for Wayland compatibility, and the Nix-installed binary includes wrappers for these variables. [[1]](diffhunk://#diff-6ebdb617a8104a7756d0cf36578ab01103dc9f07e4dc6feb751296b9c402faf7R37-R59) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R34-R60)
* Provided CLI instructions for MCP registration on Linux, as settings file configuration is not supported. [[1]](diffhunk://#diff-6ebdb617a8104a7756d0cf36578ab01103dc9f07e4dc6feb751296b9c402faf7R37-R59) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R73-R78)

**Documentation and Platform Updates:**
* Updated `README.md` and `docs/features.md` to reflect Linux (NixOS/Wayland) as a supported platform, including details about required environment variables for correct rendering under Wayland. Windows is noted as untested. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L5-R5) [[2]](diffhunk://#diff-aff15ced1fe37506f41f2e1d93a4d8312529259f7803f8634ffb5eac4de47823L279-R283)
* Clarified and separated installation and build instructions for macOS and Linux in the documentation, including usage notes specific to each platform. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R17-R24) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R34-R60)

**Cross-Platform Usability Improvements:**
* Updated keyboard shortcut documentation to include both macOS (`Cmd`) and Linux/Windows (`Ctrl`) variants for search and save actions.