### PR TITLE
ci: add ci workflow for PRs and dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,17 @@
+version: 2
+
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+
+  - package-ecosystem: npm
+    directory: /
+    schedule:
+      interval: weekly
+
+  - package-ecosystem: cargo
+    directory: /src-tauri
+    schedule:
+      interval: weekly

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,8 +31,6 @@ jobs:
             libgstreamer-plugins-bad1.0-dev
 
       - uses: pnpm/action-setup@v4
-        with:
-          version: 8.10.2
 
       - uses: actions/setup-node@v4
         with:
@@ -64,8 +62,6 @@ jobs:
       - uses: actions/checkout@v4
 
       - uses: pnpm/action-setup@v4
-        with:
-          version: 8.10.2
 
       - uses: actions/setup-node@v4
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,91 @@
+name: CI
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+
+jobs:
+  build-ubuntu:
+    name: Build & Test (Ubuntu)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install system dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends \
+            libwebkit2gtk-4.1-dev \
+            build-essential \
+            file \
+            libxdo-dev \
+            libssl-dev \
+            libayatana-appindicator3-dev \
+            librsvg2-dev \
+            libgstreamer1.0-dev \
+            libgstreamer-plugins-base1.0-dev \
+            gstreamer1.0-plugins-good \
+            gstreamer1.0-plugins-bad \
+            libgstreamer-plugins-bad1.0-dev
+
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 8.10.2
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - uses: dtolnay/rust-toolchain@stable
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: src-tauri
+
+      - name: Install Node dependencies
+        run: pnpm install
+
+      - name: Frontend tests
+        run: pnpm test
+
+      - name: Rust tests
+        run: pnpm test:rust
+
+      - name: Build
+        run: pnpm tauri build --debug
+
+  build-macos:
+    name: Build & Test (macOS)
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 8.10.2
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - uses: dtolnay/rust-toolchain@stable
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: src-tauri
+
+      - name: Install Node dependencies
+        run: pnpm install
+
+      - name: Frontend tests
+        run: pnpm test
+
+      - name: Rust tests
+        run: pnpm test:rust
+
+      - name: Build
+        run: pnpm tauri build --debug


### PR DESCRIPTION
This pull request introduces automated dependency management and continuous integration (CI) workflows for the project. The main changes are the addition of a `.github/dependabot.yml` file to keep dependencies up to date, and a new `.github/workflows/ci.yml` file to run builds and tests on both Ubuntu and macOS environments using GitHub Actions.

**Automated dependency management:**

* Added `.github/dependabot.yml` to enable weekly checks and updates for GitHub Actions, npm, and Cargo dependencies in the relevant directories.

**Continuous integration workflows:**

* Added `.github/workflows/ci.yml` to define CI workflows that trigger on pushes and pull requests to the `main` branch. The workflow installs dependencies, runs frontend and Rust tests, and builds the project on both Ubuntu and macOS environments.
* The CI pipeline includes steps for setting up Node.js and Rust toolchains, caching dependencies, and running platform-specific build and test commands.

I shall add, some lint and formatting checks to the pipeline in a follow up PR.