### PR TITLE
chore(deps): group dependabot updates and use hyphen separator

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,13 +5,37 @@ updates:
     directory: /
     schedule:
       interval: weekly
+    pull-request-branch-name:
+      separator: '-'
+    groups:
+      stable-updates:
+        update-types:
+          - "major"
+          - "minor"
+          - "patch"
 
   - package-ecosystem: npm
     directory: /
     schedule:
       interval: weekly
+    pull-request-branch-name:
+      separator: '-'
+    groups:
+      stable-updates:
+        update-types:
+          - "major"
+          - "minor"
+          - "patch"
 
   - package-ecosystem: cargo
     directory: /src-tauri
     schedule:
       interval: weekly
+    pull-request-branch-name:
+      separator: '-'
+    groups:
+      stable-updates:
+        update-types:
+          - "major"
+          - "minor"
+          - "patch"


### PR DESCRIPTION
This pull request updates the `.github/dependabot.yml` configuration to improve how Dependabot manages and groups dependency updates. The main changes standardize branch naming and group all update types (major, minor, patch) into a single group for each package ecosystem.

Dependabot configuration improvements:

* Added a custom branch name separator (`-`) for pull request branches to ensure consistency across all package ecosystems. (.github/dependabot.yml)
* Introduced a `stable-updates` group for each package ecosystem (`updates`, `npm`, `cargo`) to combine major, minor, and patch updates into a single pull request group, simplifying dependency management. (.github/dependabot.yml)