### PR TITLE
feat: add support for darwin in flake.

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,18 @@ pnpm tauri build
 </details>
 
 <details>
+<summary>Build from source (macOS — with Nix)</summary>
+
+```bash
+git clone https://github.com/denolehov/annot.git && cd annot
+nix develop          # enter dev shell with all build dependencies
+pnpm install
+pnpm tauri build     # .app bundle at src-tauri/target/release/bundle/macos/
+```
+
+</details>
+
+<details>
 <summary>Build from source (Ubuntu)</summary>
 
 Install system dependencies:
@@ -77,7 +89,7 @@ pnpm tauri build     # binary at src-tauri/target/release/annot
 Or install into your Nix profile (wraps the binary with required env vars):
 
 ```bash
-nix profile install path:.
+nix profile add path:.
 ```
 
 > **Wayland note**: The installed binary automatically sets `GDK_BACKEND=x11` and

--- a/flake.lock
+++ b/flake.lock
@@ -20,16 +20,16 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1779796641,
-        "narHash": "sha256-ZsIrKmhp4vbBXoXXmR/tBXA/UCsAQiJL9vsgZEduhVY=",
+        "lastModified": 1779560665,
+        "narHash": "sha256-tpyBcxPpcQb8ukyNF7DoCwfSY3VPsxHoYwj00Cayv5o=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "25f538306313eae3927264466c70d7001dcea1df",
+        "rev": "64c08a7ca051951c8eae34e3e3cb1e202fe36786",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
-        "ref": "nixos-25.11",
+        "ref": "nixos-unstable",
         "repo": "nixpkgs",
         "type": "github"
       }

--- a/flake.lock
+++ b/flake.lock
@@ -20,11 +20,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1778430510,
-        "narHash": "sha256-Ti+ZBvW6yrWWAg2szExVTwCd4qOJ3KlVr1tFHfyfi8Q=",
+        "lastModified": 1779796641,
+        "narHash": "sha256-ZsIrKmhp4vbBXoXXmR/tBXA/UCsAQiJL9vsgZEduhVY=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "8fd9daa3db09ced9700431c5b7ad0e8ba199b575",
+        "rev": "25f538306313eae3927264466c70d7001dcea1df",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -1,38 +1,65 @@
 {
-  description = "annot dev shell — Tauri v2 + SvelteKit on Linux";
+  description = "annot — Human-in-the-loop annotation for AI workflows (Tauri v2 + SvelteKit)";
 
   inputs = {
     nixpkgs.url = "github:NixOS/nixpkgs/nixos-25.11";
     flake-utils.url = "github:numtide/flake-utils";
   };
 
-  outputs = { self, nixpkgs, flake-utils }:
-    flake-utils.lib.eachDefaultSystem (system:
+  outputs =
+    {
+      self,
+      nixpkgs,
+      flake-utils,
+    }:
+    flake-utils.lib.eachDefaultSystem (
+      system:
       let
         pkgs = nixpkgs.legacyPackages.${system};
+        isDarwin = pkgs.stdenv.hostPlatform.isDarwin;
+        isLinux = pkgs.stdenv.hostPlatform.isLinux;
 
-        # Runtime env vars needed by the binary (same as devShell)
-        gstPluginPath = pkgs.lib.concatStringsSep ":" [
-          "${pkgs.gst_all_1.gstreamer.out}/lib/gstreamer-1.0"
-          "${pkgs.gst_all_1.gst-plugins-base}/lib/gstreamer-1.0"
-          "${pkgs.gst_all_1.gst-plugins-good}/lib/gstreamer-1.0"
-          "${pkgs.gst_all_1.gst-plugins-bad}/lib/gstreamer-1.0"
-        ];
-      in {
+        # GStreamer plugin path for WebKit2GTK media support (Linux only)
+        gstPluginPath = pkgs.lib.optionalString isLinux (
+          pkgs.lib.concatStringsSep ":" [
+            "${pkgs.gst_all_1.gstreamer.out}/lib/gstreamer-1.0"
+            "${pkgs.gst_all_1.gst-plugins-base}/lib/gstreamer-1.0"
+            "${pkgs.gst_all_1.gst-plugins-good}/lib/gstreamer-1.0"
+            "${pkgs.gst_all_1.gst-plugins-bad}/lib/gstreamer-1.0"
+          ]
+        );
+      in
+      {
+        # Formatter (nixfmt-rfc-style)
+        formatter = pkgs.nixfmt-rfc-style;
+
+        # Binary package (requires pre-built artifacts from `pnpm tauri build`)
         # Install with: nix profile install path:.
-        # Requires the binary to be pre-built: pnpm tauri build
-        packages.default = pkgs.runCommand "annot" {
-          nativeBuildInputs = [ pkgs.makeWrapper ];
-          meta.mainProgram = "annot";
-        } ''
-          mkdir -p $out/bin
-          makeWrapper ${./src-tauri/target/release/annot} $out/bin/annot \
-            --set GDK_BACKEND x11 \
-            --set WEBKIT_DISABLE_DMABUF_RENDERER 1 \
-            --set GST_PLUGIN_SYSTEM_PATH "${gstPluginPath}" \
-            --set GIO_MODULE_DIR "${pkgs.glib-networking}/lib/gio/modules"
-        '';
+        packages.default =
+          pkgs.runCommand "annot"
+            {
+              nativeBuildInputs = [ pkgs.makeWrapper ];
+              meta.mainProgram = "annot";
+            }
+            (
+              if isDarwin then
+                ''
+                  mkdir -p $out/{bin,Applications}
+                  cp -r ${./src-tauri/target/release/bundle/macos/annot.app} $out/Applications/
+                  makeWrapper $out/Applications/annot.app/Contents/MacOS/annot $out/bin/annot
+                ''
+              else
+                ''
+                  mkdir -p $out/bin
+                  makeWrapper ${./src-tauri/target/release/annot} $out/bin/annot \
+                    --set GDK_BACKEND x11 \
+                    --set WEBKIT_DISABLE_DMABUF_RENDERER 1 \
+                    --set GST_PLUGIN_SYSTEM_PATH "${gstPluginPath}" \
+                    --set GIO_MODULE_DIR "${pkgs.glib-networking}/lib/gio/modules"
+                ''
+            );
 
+        # Development shell
         devShells.default = pkgs.mkShell {
           nativeBuildInputs = with pkgs; [
             pkg-config
@@ -44,56 +71,61 @@
             pnpm
           ];
 
-          buildInputs = with pkgs; [
-            # Tauri v2 requires WebKit2GTK 4.1 (not 4.0)
-            webkitgtk_4_1
-            gtk3
-            glib
-            glib-networking   # TLS support for WebKit
-            libsoup_3
-            openssl
-            cairo
-            pango
-            gdk-pixbuf
-            librsvg
-            at-spi2-atk
-            at-spi2-core
+          buildInputs =
+            with pkgs;
+            [ openssl ]
+            ++ pkgs.lib.optionals isLinux [
+              # Tauri v2 WebView (WebKit2GTK 4.1)
+              webkitgtk_4_1
+              gtk3
+              glib
+              glib-networking
+              libsoup_3
+              cairo
+              pango
+              gdk-pixbuf
+              librsvg
+              at-spi2-atk
+              at-spi2-core
 
-            # GStreamer — required by WebKit2GTK for media/video support
-            gst_all_1.gstreamer
-            gst_all_1.gst-plugins-base   # provides appsink
-            gst_all_1.gst-plugins-good
-            gst_all_1.gst-plugins-bad
+              # GStreamer (media/video support for WebKit)
+              gst_all_1.gstreamer
+              gst_all_1.gst-plugins-base
+              gst_all_1.gst-plugins-good
+              gst_all_1.gst-plugins-bad
 
-            # arboard (clipboard) — X11 backend
-            libxcb
-            xclip
+              # Clipboard support (arboard X11 backend)
+              libxcb
+              xclip
 
-            # tauri-plugin-opener uses xdg-open on Linux
-            xdg-utils
-          ];
+              # tauri-plugin-opener
+              xdg-utils
+            ];
 
-          # PKG_CONFIG_PATH is usually set automatically by mkShell for buildInputs,
-          # but openssl sometimes needs a nudge.
           shellHook = ''
-            export PKG_CONFIG_PATH="${pkgs.openssl.dev}/lib/pkgconfig:${pkgs.webkitgtk_4_1.dev}/lib/pkgconfig:$PKG_CONFIG_PATH"
+            # OpenSSL pkg-config path
+            export PKG_CONFIG_PATH="${pkgs.openssl.dev}/lib/pkgconfig:$PKG_CONFIG_PATH"
 
-            # GStreamer plugin path so WebKit2GTK can find appsink and friends
-            export GST_PLUGIN_SYSTEM_PATH="${pkgs.gst_all_1.gstreamer.out}/lib/gstreamer-1.0:${pkgs.gst_all_1.gst-plugins-base}/lib/gstreamer-1.0:${pkgs.gst_all_1.gst-plugins-good}/lib/gstreamer-1.0:${pkgs.gst_all_1.gst-plugins-bad}/lib/gstreamer-1.0"
+            ${pkgs.lib.optionalString isLinux ''
+              # WebKitGTK pkg-config
+              export PKG_CONFIG_PATH="${pkgs.webkitgtk_4_1.dev}/lib/pkgconfig:$PKG_CONFIG_PATH"
 
-            # Force XWayland — WebKit2GTK's native Wayland/DMABuf renderer is broken on NixOS
-            export GDK_BACKEND=x11
-            export WEBKIT_DISABLE_DMABUF_RENDERER=1
+              # GStreamer plugin discovery
+              export GST_PLUGIN_SYSTEM_PATH="${gstPluginPath}"
 
-            # GIO modules path so glib-networking (TLS) is found by WebKit at runtime
-            export GIO_MODULE_DIR="${pkgs.glib-networking}/lib/gio/modules"
+              # Force X11 (WebKit2GTK Wayland/DMABuf is broken on NixOS)
+              export GDK_BACKEND=x11
+              export WEBKIT_DISABLE_DMABUF_RENDERER=1
 
-            # pnpm@10.28.0 is pinned in package.json; nixpkgs ships the same version.
-            # Disable strict corepack enforcement so the nixpkgs pnpm binary is used directly.
+              # GIO modules for TLS support
+              export GIO_MODULE_DIR="${pkgs.glib-networking}/lib/gio/modules"
+            ''}
+
+            # Use nixpkgs pnpm directly (disable corepack strict mode)
             export COREPACK_ENABLE_STRICT=0
 
-            echo "annot dev shell ready"
-            echo "  pnpm install     — install JS deps"
+            echo "annot dev shell ready (${if isDarwin then "macOS" else "Linux"})"
+            echo "  pnpm install     — install JS dependencies"
             echo "  pnpm tauri dev   — start dev server + Tauri window"
             echo "  pnpm tauri build — production build"
           '';

--- a/flake.nix
+++ b/flake.nix
@@ -2,7 +2,7 @@
   description = "annot — Human-in-the-loop annotation for AI workflows (Tauri v2 + SvelteKit)";
 
   inputs = {
-    nixpkgs.url = "github:NixOS/nixpkgs/nixos-25.11";
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
     flake-utils.url = "github:numtide/flake-utils";
   };
 
@@ -30,8 +30,8 @@
         );
       in
       {
-        # Formatter (nixfmt-rfc-style)
-        formatter = pkgs.nixfmt-rfc-style;
+        # Formatter (nixfmt)
+        formatter = pkgs.nixfmt;
 
         # Binary package (requires pre-built artifacts from `pnpm tauri build`)
         # Install with: nix profile add path:.

--- a/flake.nix
+++ b/flake.nix
@@ -34,7 +34,8 @@
         formatter = pkgs.nixfmt-rfc-style;
 
         # Binary package (requires pre-built artifacts from `pnpm tauri build`)
-        # Install with: nix profile install path:.
+        # Install with: nix profile add path:.
+        # Remove with: nix profile remove annot
         packages.default =
           pkgs.runCommand "annot"
             {
@@ -128,6 +129,10 @@
             echo "  pnpm install     — install JS dependencies"
             echo "  pnpm tauri dev   — start dev server + Tauri window"
             echo "  pnpm tauri build — production build"
+            echo "  pnpm demo        — open demo with test fixture"
+            echo "  pnpm test        — run vitest suite"
+            echo "  pnpm check       — svelte-check typecheck"
+            echo "  pnpm run         — list all available scripts"
           '';
         };
       }


### PR DESCRIPTION
Extend `flake.nix` to support Darwin (MacOS) and minor refactors.

This pull request updates the Nix flake setup and documentation to improve cross-platform support (especially for macOS), streamline developer experience, and clarify build instructions. The most significant changes are the addition of macOS build support, improved environment configuration, and more user-friendly documentation.

**Nix flake improvements and cross-platform support:**

* Updated `flake.nix` to support both macOS and Linux, including platform-specific build logic for packaging the application bundle on macOS and setting up the correct environment variables for each OS.
* Improved the development shell setup with clearer instructions, additional helper messages, and extended environment variable configuration for both platforms.

**Documentation and usage updates:**

* Added a new section to `README.md` with step-by-step instructions for building from source on macOS using Nix, making it easier for macOS users to get started.
* Updated the Nix installation command in the `README.md` from `nix profile install` to the current `nix profile add` for clarity and accuracy.

**Other improvements:**

* Changed the flake description to better reflect the project's purpose and updated the Nixpkgs channel to `nixos-unstable` for more up-to-date dependencies.