### PR TITLE
fix(linux): honor Ctrl+D in command palette delete handlers

### DIFF
--- a/src/lib/CommandPalette/CommandPalette.svelte
+++ b/src/lib/CommandPalette/CommandPalette.svelte
@@ -292,8 +292,8 @@
         dispatch({ type: 'TAB' });
         return;
       }
-      // Cmd-D: delete item being edited (EDIT_FORM only)
-      if (e.key === 'd' && e.metaKey && machineState.type === 'EDIT_FORM') {
+      // Cmd-D / Ctrl-D: delete item being edited (EDIT_FORM only)
+      if (e.key === 'd' && (e.metaKey || e.ctrlKey) && machineState.type === 'EDIT_FORM') {
         e.preventDefault();
         dispatch({ type: 'DELETE' });
         return;
@@ -346,8 +346,8 @@
     } else if (e.key === 'ArrowDown') {
       e.preventDefault();
       dispatch({ type: 'ARROW_DOWN' });
-    } else if (e.key === 'd' && e.metaKey && machineState.type === 'ITEM_FILTER') {
-      // Cmd-D: delete selected/preselected item
+    } else if (e.key === 'd' && (e.metaKey || e.ctrlKey) && machineState.type === 'ITEM_FILTER') {
+      // Cmd-D / Ctrl-D: delete selected/preselected item
       e.preventDefault();
       dispatch({ type: 'DELETE' });
     } else if (e.key === 'Backspace') {


### PR DESCRIPTION
The two delete shortcuts in CommandPalette.svelte (EDIT_FORM and ITEM_FILTER states) gated on e.metaKey only, which is the Cmd key on macOS but maps to Super/Windows key on Linux — leaving Ctrl+D silently unhandled even though the on-screen hint promised it (the hint renders keys.cmd which already resolves to "Ctrl" on non-macOS).

Switches both handlers to (e.metaKey || e.ctrlKey), matching the cross-platform pattern already used elsewhere in the same file (line 334 for Cmd/Ctrl+Enter).