### PR TITLE
Borderless window for linux

### DIFF
--- a/docs/features.md
+++ b/docs/features.md
@@ -277,7 +277,8 @@ Atomic writes with file locking for concurrent safety.
 
 Native Tauri app for:
 - **macOS** — overlay title bar, traffic light positioning, native Cmd+W close
-- **Linux** — tested on NixOS with Wayland (via XWayland); requires `GDK_BACKEND=x11`
-  and `WEBKIT_DISABLE_DMABUF_RENDERER=1` for correct WebKit2GTK rendering (baked into
-  the Nix-installed binary automatically)
+- **Linux** — borderless window with custom chrome (in-app title bar, close button,
+  and resize handles); tested on NixOS with Wayland (via XWayland); requires
+  `GDK_BACKEND=x11` and `WEBKIT_DISABLE_DMABUF_RENDERER=1` for correct WebKit2GTK
+  rendering (baked into the Nix-installed binary automatically)
 - Windows (untested)

--- a/src-tauri/src/excalidraw_window.rs
+++ b/src-tauri/src/excalidraw_window.rs
@@ -155,6 +155,8 @@ pub fn open_excalidraw_window(
             .title_bar_style(tauri::TitleBarStyle::Overlay)
             .hidden_title(true)
             .traffic_light_position(tauri::LogicalPosition::new(12.0, 22.0));
+        #[cfg(target_os = "linux")]
+        let b = b.decorations(false);
         b
     };
 

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -148,6 +148,8 @@ pub fn run(state: AppState, context: tauri::Context, json_output: bool) {
                     .title_bar_style(tauri::TitleBarStyle::Overlay)
                     .hidden_title(true)
                     .traffic_light_position(tauri::LogicalPosition::new(12.0, 22.0));
+                #[cfg(target_os = "linux")]
+                let b = b.decorations(false);
                 b
             };
 

--- a/src-tauri/src/mcp/mod.rs
+++ b/src-tauri/src/mcp/mod.rs
@@ -422,6 +422,8 @@ fn run_session_with_state(
             .title_bar_style(tauri::TitleBarStyle::Overlay)
             .hidden_title(true)
             .traffic_light_position(tauri::LogicalPosition::new(12.0, 22.0));
+        #[cfg(target_os = "linux")]
+        let b = b.decorations(false);
         b
     };
 

--- a/src-tauri/src/mermaid_window.rs
+++ b/src-tauri/src/mermaid_window.rs
@@ -99,6 +99,8 @@ pub fn open_mermaid_window(
             .title_bar_style(tauri::TitleBarStyle::Overlay)
             .hidden_title(true)
             .traffic_light_position(tauri::LogicalPosition::new(12.0, 22.0));
+        #[cfg(target_os = "linux")]
+        let b = b.decorations(false);
         b
     };
 

--- a/src/app.d.ts
+++ b/src/app.d.ts
@@ -1,0 +1,7 @@
+// Global ambient declarations for build-time defines (see vite.config.js).
+
+declare global {
+  const __IS_MACOS__: boolean;
+}
+
+export {};

--- a/src/lib/components/Header.svelte
+++ b/src/lib/components/Header.svelte
@@ -3,7 +3,10 @@
   import Icon from '$lib/CommandPalette/Icon.svelte';
   import { BookmarkIcon } from '$lib/icons';
   import { getAnnotContext } from '$lib/context';
+  import { getCurrentWindow } from '@tauri-apps/api/window';
   import type { DiffFileInfo, HunkInfo, SectionInfo } from '$lib/types';
+
+  declare const __IS_MACOS__: boolean;
 
   interface Props {
     label: string;
@@ -126,11 +129,25 @@
     <button class="header-btn" onclick={onOpenSaveModal} title="Save to file (Cmd+S)">
       <Icon name="save" />
     </button>
+    {#if !__IS_MACOS__}
+      <button class="header-btn close-btn" onclick={() => getCurrentWindow().close()} title="Close (Ctrl+W)">
+        ×
+      </button>
+    {/if}
   </div>
 </header>
 
 <style>
   .bookmark-btn.bookmarked {
+    color: #ef4444;
+  }
+
+  .close-btn {
+    font-size: 16px;
+    line-height: 1;
+  }
+
+  .close-btn:hover {
     color: #ef4444;
   }
 </style>

--- a/src/lib/components/Header.svelte
+++ b/src/lib/components/Header.svelte
@@ -6,8 +6,6 @@
   import { getCurrentWindow } from '@tauri-apps/api/window';
   import type { DiffFileInfo, HunkInfo, SectionInfo } from '$lib/types';
 
-  declare const __IS_MACOS__: boolean;
-
   interface Props {
     label: string;
     currentFile: DiffFileInfo | null;

--- a/src/lib/components/WindowResizeHandles.svelte
+++ b/src/lib/components/WindowResizeHandles.svelte
@@ -1,7 +1,16 @@
 <script lang="ts">
-  import { getCurrentWindow, type ResizeDirection } from '@tauri-apps/api/window';
+  import { getCurrentWindow } from '@tauri-apps/api/window';
 
-  declare const __IS_MACOS__: boolean;
+  // ResizeDirection is declared in @tauri-apps/api/window.d.ts but not exported, so inline it here.
+  type ResizeDirection =
+    | 'East'
+    | 'North'
+    | 'NorthEast'
+    | 'NorthWest'
+    | 'South'
+    | 'SouthEast'
+    | 'SouthWest'
+    | 'West';
 
   function onMouseDown(direction: ResizeDirection) {
     return (e: MouseEvent) => {

--- a/src/lib/components/WindowResizeHandles.svelte
+++ b/src/lib/components/WindowResizeHandles.svelte
@@ -1,0 +1,44 @@
+<script lang="ts">
+  import { getCurrentWindow, type ResizeDirection } from '@tauri-apps/api/window';
+
+  declare const __IS_MACOS__: boolean;
+
+  function onMouseDown(direction: ResizeDirection) {
+    return (e: MouseEvent) => {
+      e.preventDefault();
+      getCurrentWindow().startResizeDragging(direction);
+    };
+  }
+</script>
+
+{#if !__IS_MACOS__}
+  <!-- Corners (larger hit areas, rendered on top of edges) -->
+  <div class="handle corner nw" onmousedown={onMouseDown('NorthWest')} role="presentation"></div>
+  <div class="handle corner ne" onmousedown={onMouseDown('NorthEast')} role="presentation"></div>
+  <div class="handle corner sw" onmousedown={onMouseDown('SouthWest')} role="presentation"></div>
+  <div class="handle corner se" onmousedown={onMouseDown('SouthEast')} role="presentation"></div>
+  <!-- Edges -->
+  <div class="handle edge n"  onmousedown={onMouseDown('North')} role="presentation"></div>
+  <div class="handle edge s"  onmousedown={onMouseDown('South')} role="presentation"></div>
+  <div class="handle edge w"  onmousedown={onMouseDown('West')}  role="presentation"></div>
+  <div class="handle edge e"  onmousedown={onMouseDown('East')}  role="presentation"></div>
+{/if}
+
+<style>
+  .handle {
+    position: fixed;
+    z-index: 9999;
+  }
+
+  /* Edges */
+  .edge.n { top: 0;    left: 0;    right: 0;    height: 5px; cursor: n-resize;  }
+  .edge.s { bottom: 0; left: 0;    right: 0;    height: 5px; cursor: s-resize;  }
+  .edge.w { left: 0;   top: 0;     bottom: 0;   width: 5px;  cursor: w-resize;  }
+  .edge.e { right: 0;  top: 0;     bottom: 0;   width: 5px;  cursor: e-resize;  }
+
+  /* Corners (12px, overlap edges, z-index already higher via DOM order) */
+  .corner.nw { top: 0;    left: 0;   width: 12px; height: 12px; cursor: nw-resize; }
+  .corner.ne { top: 0;    right: 0;  width: 12px; height: 12px; cursor: ne-resize; }
+  .corner.sw { bottom: 0; left: 0;   width: 12px; height: 12px; cursor: sw-resize; }
+  .corner.se { bottom: 0; right: 0;  width: 12px; height: 12px; cursor: se-resize; }
+</style>

--- a/src/lib/components/WindowResizeHandles.svelte
+++ b/src/lib/components/WindowResizeHandles.svelte
@@ -12,16 +12,16 @@
 </script>
 
 {#if !__IS_MACOS__}
-  <!-- Corners (larger hit areas, rendered on top of edges) -->
-  <div class="handle corner nw" onmousedown={onMouseDown('NorthWest')} role="presentation"></div>
-  <div class="handle corner ne" onmousedown={onMouseDown('NorthEast')} role="presentation"></div>
-  <div class="handle corner sw" onmousedown={onMouseDown('SouthWest')} role="presentation"></div>
-  <div class="handle corner se" onmousedown={onMouseDown('SouthEast')} role="presentation"></div>
-  <!-- Edges -->
+  <!-- Edges first so the corner handles (rendered after) win clicks at the overlap. -->
   <div class="handle edge n"  onmousedown={onMouseDown('North')} role="presentation"></div>
   <div class="handle edge s"  onmousedown={onMouseDown('South')} role="presentation"></div>
   <div class="handle edge w"  onmousedown={onMouseDown('West')}  role="presentation"></div>
   <div class="handle edge e"  onmousedown={onMouseDown('East')}  role="presentation"></div>
+  <!-- Corners (larger hit areas, must stack on top of edges) -->
+  <div class="handle corner nw" onmousedown={onMouseDown('NorthWest')} role="presentation"></div>
+  <div class="handle corner ne" onmousedown={onMouseDown('NorthEast')} role="presentation"></div>
+  <div class="handle corner sw" onmousedown={onMouseDown('SouthWest')} role="presentation"></div>
+  <div class="handle corner se" onmousedown={onMouseDown('SouthEast')} role="presentation"></div>
 {/if}
 
 <style>
@@ -36,7 +36,8 @@
   .edge.w { left: 0;   top: 0;     bottom: 0;   width: 5px;  cursor: w-resize;  }
   .edge.e { right: 0;  top: 0;     bottom: 0;   width: 5px;  cursor: e-resize;  }
 
-  /* Corners (12px, overlap edges, z-index already higher via DOM order) */
+  /* Corners (12px, must stack above edges so diagonal grabs win in the overlap) */
+  .corner { z-index: 10000; }
   .corner.nw { top: 0;    left: 0;   width: 12px; height: 12px; cursor: nw-resize; }
   .corner.ne { top: 0;    right: 0;  width: 12px; height: 12px; cursor: ne-resize; }
   .corner.sw { bottom: 0; left: 0;   width: 12px; height: 12px; cursor: sw-resize; }

--- a/src/lib/components/index.ts
+++ b/src/lib/components/index.ts
@@ -1,3 +1,4 @@
 export { default as Header } from './Header.svelte';
 export { default as StatusBar } from './StatusBar.svelte';
 export { default as SessionEditor } from './SessionEditor.svelte';
+export { default as WindowResizeHandles } from './WindowResizeHandles.svelte';

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -17,7 +17,7 @@
   import CodeBlock from "$lib/components/embedded/CodeBlock.svelte";
   import Table from "$lib/components/embedded/Table.svelte";
   import RegularLines from "$lib/components/embedded/RegularLines.svelte";
-  import { Header, StatusBar, SessionEditor } from "$lib/components";
+  import { Header, StatusBar, SessionEditor, WindowResizeHandles } from "$lib/components";
   import { useExitModes } from "$lib/composables/useExitModes.svelte";
   import { useContentTracking } from "$lib/composables/useContentTracking.svelte";
   import { useInteraction } from "$lib/composables/useInteraction.svelte";
@@ -835,6 +835,8 @@
 </script>
 
 <svelte:window onkeydown={keyboard.handleKeyDown} onkeyup={keyboard.handleKeyUp} />
+
+<WindowResizeHandles />
 
 <main class="viewer" style:--mode-color={exitModeState.selectedMode?.color ?? 'transparent'}>
   {#if error}

--- a/src/routes/excalidraw/+page.svelte
+++ b/src/routes/excalidraw/+page.svelte
@@ -228,6 +228,12 @@
     window.removeEventListener('keydown', handleKeyDown, true);
   });
 
+  async function closeWindow() {
+    // Triggers onCloseRequested, which runs the save flow
+    const win = getCurrentWindow();
+    await win.close();
+  }
+
   // Use capture phase to intercept Escape before Excalidraw handles it
   $effect(() => {
     window.addEventListener('keydown', handleKeyDown, true);
@@ -238,6 +244,15 @@
 <div class="excalidraw-window">
   <header class="window-header" data-tauri-drag-region>
     <span class="window-title">Excalidraw</span>
+    <button
+      class="window-close"
+      onclick={closeWindow}
+      title="Save and close"
+      aria-label="Save and close"
+      data-tauri-drag-region="false"
+    >
+      ×
+    </button>
   </header>
   {#if loading}
     <div class="excalidraw-loading">Loading Excalidraw...</div>
@@ -311,6 +326,32 @@
     font-size: 13px;
     font-weight: 500;
     color: var(--text-secondary);
+  }
+
+  .window-close {
+    position: absolute;
+    right: 8px;
+    top: 50%;
+    transform: translateY(-50%);
+    -webkit-app-region: no-drag;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 24px;
+    height: 24px;
+    padding: 0;
+    background: transparent;
+    border: none;
+    border-radius: 4px;
+    color: var(--text-secondary);
+    font-size: 18px;
+    line-height: 1;
+    cursor: pointer;
+  }
+
+  .window-close:hover {
+    background: var(--bg-window);
+    color: var(--text-primary);
   }
 
   .excalidraw-container {

--- a/src/routes/excalidraw/+page.svelte
+++ b/src/routes/excalidraw/+page.svelte
@@ -6,8 +6,6 @@
   import type { ExcalidrawHandle } from '$lib/excalidraw-loader';
   import { initTheme } from '$lib/theme';
 
-  declare const __IS_MACOS__: boolean;
-
   interface NodeRef {
     type: 'Chip' | 'Placeholder';
     id: string;

--- a/src/routes/excalidraw/+page.svelte
+++ b/src/routes/excalidraw/+page.svelte
@@ -6,6 +6,8 @@
   import type { ExcalidrawHandle } from '$lib/excalidraw-loader';
   import { initTheme } from '$lib/theme';
 
+  declare const __IS_MACOS__: boolean;
+
   interface NodeRef {
     type: 'Chip' | 'Placeholder';
     id: string;
@@ -244,15 +246,17 @@
 <div class="excalidraw-window">
   <header class="window-header" data-tauri-drag-region>
     <span class="window-title">Excalidraw</span>
-    <button
-      class="window-close"
-      onclick={closeWindow}
-      title="Save and close"
-      aria-label="Save and close"
-      data-tauri-drag-region="false"
-    >
-      ×
-    </button>
+    {#if !__IS_MACOS__}
+      <button
+        class="window-close"
+        onclick={closeWindow}
+        title="Save and close"
+        aria-label="Save and close"
+        data-tauri-drag-region="false"
+      >
+        ×
+      </button>
+    {/if}
   </header>
   {#if loading}
     <div class="excalidraw-loading">Loading Excalidraw...</div>

--- a/src/routes/mermaid/+page.svelte
+++ b/src/routes/mermaid/+page.svelte
@@ -7,8 +7,6 @@
 	import panzoom from 'panzoom';
 	import type { PanZoom } from 'panzoom';
 
-	declare const __IS_MACOS__: boolean;
-
 	interface MermaidContext {
 		source: string;
 		file_path: string;

--- a/src/routes/mermaid/+page.svelte
+++ b/src/routes/mermaid/+page.svelte
@@ -249,6 +249,11 @@
 			smartFit();
 		}
 	}
+
+	async function closeWindow() {
+		const win = getCurrentWindow();
+		await win.close();
+	}
 </script>
 
 <svelte:window onkeydown={handleKeyDown} />
@@ -256,6 +261,15 @@
 <div class="mermaid-window">
 	<header class="window-header" data-tauri-drag-region>
 		<span class="window-title">Mermaid</span>
+		<button
+			class="window-close"
+			onclick={closeWindow}
+			title="Close"
+			aria-label="Close"
+			data-tauri-drag-region="false"
+		>
+			×
+		</button>
 	</header>
 	{#if loading}
 		<div class="mermaid-loading">Rendering diagram...</div>
@@ -307,6 +321,32 @@
 		font-size: 13px;
 		font-weight: 500;
 		color: var(--text-secondary);
+	}
+
+	.window-close {
+		position: absolute;
+		right: 8px;
+		top: 50%;
+		transform: translateY(-50%);
+		-webkit-app-region: no-drag;
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		width: 24px;
+		height: 24px;
+		padding: 0;
+		background: transparent;
+		border: none;
+		border-radius: 4px;
+		color: var(--text-secondary);
+		font-size: 18px;
+		line-height: 1;
+		cursor: pointer;
+	}
+
+	.window-close:hover {
+		background: var(--bg-window);
+		color: var(--text-primary);
 	}
 
 	.mermaid-canvas {

--- a/src/routes/mermaid/+page.svelte
+++ b/src/routes/mermaid/+page.svelte
@@ -7,6 +7,8 @@
 	import panzoom from 'panzoom';
 	import type { PanZoom } from 'panzoom';
 
+	declare const __IS_MACOS__: boolean;
+
 	interface MermaidContext {
 		source: string;
 		file_path: string;
@@ -261,15 +263,17 @@
 <div class="mermaid-window">
 	<header class="window-header" data-tauri-drag-region>
 		<span class="window-title">Mermaid</span>
-		<button
-			class="window-close"
-			onclick={closeWindow}
-			title="Close"
-			aria-label="Close"
-			data-tauri-drag-region="false"
-		>
-			×
-		</button>
+		{#if !__IS_MACOS__}
+			<button
+				class="window-close"
+				onclick={closeWindow}
+				title="Close"
+				aria-label="Close"
+				data-tauri-drag-region="false"
+			>
+				×
+			</button>
+		{/if}
 	</header>
 	{#if loading}
 		<div class="mermaid-loading">Rendering diagram...</div>


### PR DESCRIPTION
This pull request implements a custom borderless window experience for Linux in the Tauri app, including in-app window controls and resize handles, to provide a consistent and native-feeling UI across platforms. It also updates the documentation to reflect these changes and ensures that close buttons and resize handles are only shown on non-macOS platforms. The most important changes are grouped below:

**Linux borderless window support:**

* On Linux, Tauri windows are now created without system decorations (`decorations(false)`), enabling a fully custom chrome with in-app title bar, close button, and resize handles. This is applied to all relevant windows in the backend Rust code (`excalidraw_window.rs`, `mermaid_window.rs`, `mcp/mod.rs`, `lib.rs`). [[1]](diffhunk://#diff-8e2f8665921d382595b253bb6b3451b349c2a369396ba60633d5cbcc9337274bR158-R159) [[2]](diffhunk://#diff-ec0420a217fe2c0212572762a2482bf025e9dc3289d8c5c4ed29ab8e511fea15R102-R103) [[3]](diffhunk://#diff-608f9a440bb17c0fe29e5dda50b72469c7c8a6c3c809f97ed906a1f2040f6180R425-R426) [[4]](diffhunk://#diff-eabcebd0ae5c9b77a5247e1bdbdb88b1869fc0c932d0ef0cf2ecf9ee5221be7cR151-R152)
* Documentation is updated to describe the new Linux window behavior, including the presence of custom chrome and requirements for correct rendering.

**Custom window controls and resize handles (frontend):**

* Adds a new `WindowResizeHandles.svelte` component, which provides draggable edges and corners for resizing the window, and integrates it into the main page layout for non-macOS platforms. [[1]](diffhunk://#diff-4cc1d90c1febcac89f267b94bc5a9019d1e132ac66568be0e57bdce44dbe87ecR1-R54) [[2]](diffhunk://#diff-1e1270da740e81dd13f8a65057582b0fce8a5fb3817ef913f3e90d7f82c4e9dfL20-R20) [[3]](diffhunk://#diff-1e1270da740e81dd13f8a65057582b0fce8a5fb3817ef913f3e90d7f82c4e9dfR839-R840) [[4]](diffhunk://#diff-7f4a6c58dd4ebeef4a6f84c5a34bdaaaf8e4f7abcde7f710be5d5430cb0469a3R4)
* Implements custom close buttons in the main header and in the Excalidraw and Mermaid tool windows, only visible on non-macOS platforms, using Tauri's window API to trigger window close actions. [[1]](diffhunk://#diff-d63bb57c0fd5d7db72c5d4e58fc50955859ad6262317c71261740ffbba2b6d25R130-R150) [[2]](diffhunk://#diff-85819649a299be0b721d3492f41981364c6fe55772882ae653cd27856090c2c0R231-R236) [[3]](diffhunk://#diff-85819649a299be0b721d3492f41981364c6fe55772882ae653cd27856090c2c0R247-R257) [[4]](diffhunk://#diff-a580cdb3e9c360e6724eaf828280baed492157f95187cc47ad17dc0b855fe78eR252-R274)

**Styling and UX improvements:**

* Adds and styles the new close buttons and resize handles to visually integrate with the app and provide clear interactive feedback on hover. [[1]](diffhunk://#diff-d63bb57c0fd5d7db72c5d4e58fc50955859ad6262317c71261740ffbba2b6d25R130-R150) [[2]](diffhunk://#diff-85819649a299be0b721d3492f41981364c6fe55772882ae653cd27856090c2c0R333-R358) [[3]](diffhunk://#diff-a580cdb3e9c360e6724eaf828280baed492157f95187cc47ad17dc0b855fe78eR328-R353) [[4]](diffhunk://#diff-4cc1d90c1febcac89f267b94bc5a9019d1e132ac66568be0e57bdce44dbe87ecR1-R54)

These changes ensure a consistent, platform-appropriate windowing experience, especially on Linux, where custom chrome is now fully supported.