### PR TITLE
test: add document.elementFromPoint mock for jsdom

### DIFF
--- a/src/test-setup.ts
+++ b/src/test-setup.ts
@@ -5,3 +5,12 @@ import { vi } from "vitest";
 vi.mock("@tauri-apps/api/core", () => ({
   invoke: vi.fn().mockResolvedValue([]),
 }));
+
+// Mock document.elementFromPoint (not available in jsdom)
+// Needed by TipTap's placeholder extension when calculating viewport positions
+if (typeof document !== 'undefined' && !document.elementFromPoint) {
+  // @ts-ignore - adding missing jsdom method
+  document.elementFromPoint = vi.fn((x: number, y: number) => {
+    return document.body;
+  });
+}


### PR DESCRIPTION
Fixes failing test 'opens editor when c is pressed alone on hovered line' by mocking document.elementFromPoint which is not available in jsdom but required by TipTap's placeholder extension when calculating viewport positions.

@denolehov: Merge this into the dependabot branch and then the dependabot branch into `main`