### PR TITLE
fix(linux): grant start-resize-dragging permission

### DIFF
--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -6,6 +6,7 @@
   "permissions": [
     "core:default",
     "core:window:allow-start-dragging",
+    "core:window:allow-start-resize-dragging",
     "core:window:allow-close",
     "core:window:allow-show",
     "core:window:allow-destroy",


### PR DESCRIPTION
The WindowResizeHandles component called startResizeDragging() but the capability for it was never added to default.json, so every mousedown on an edge/corner handle was silently rejected with an unhandled promise rejection. The visible resize behavior came from the WM's own pixel-perfect edge detection on the bare borderless window, which is why diagonal corner resize felt "very tight" — our explicit direction hints never reached Tauri.