### PR TITLE
fix: use claude mcp add CLI for all platforms in Claude Code setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,26 +127,7 @@ add the `src-tauri\target\release\` directory to your `PATH`, or reference the `
 
 ### With Claude Code
 
-**macOS** — add to your MCP settings (`~/.claude/settings.json` or project `.claude/settings.json`):
-
-```json
-{
-  "mcpServers": {
-    "annot": {
-      "command": "annot",
-      "args": ["mcp"]
-    }
-  }
-}
-```
-
-**Linux** — use the CLI instead:
-
-```bash
-claude mcp add --scope user annot annot mcp
-```
-
-**Windows** — use the CLI (same as Linux):
+Run the following command on **macOS**, **Linux**, or **Windows**:
 
 ```bash
 claude mcp add --scope user annot annot mcp


### PR DESCRIPTION
## Summary

Fixes #69

The README's macOS section showed a JSON snippet instructing users to add `mcpServers` to `~/.claude/settings.json`. This is incorrect — `mcpServers` is not a recognized field in Claude Code's `settings.json` and the validator rejects it with:

> Unrecognized field: mcpServers

Per the [official Claude Code MCP documentation](https://code.claude.com/docs/en/mcp), MCP servers are stored in `~/.claude.json` and configured via the `claude mcp add` CLI command.

## Change

- Removes the incorrect JSON snippet for macOS
- Replaces the three separate platform sections (macOS/Linux/Windows) with a single cross-platform `claude mcp add` command