### PR TITLE
fix(linux): enable scrollbar interaction in borderless window

### DIFF
--- a/src/styles/base.css
+++ b/src/styles/base.css
@@ -32,10 +32,12 @@ code {
 ::-webkit-scrollbar {
 	width: 6px;
 	height: 6px;
+	-webkit-app-region: no-drag; /* Allow scrollbar interaction in borderless windows */
 }
 
 ::-webkit-scrollbar-track {
 	background: transparent;
+	-webkit-app-region: no-drag;
 }
 
 ::-webkit-scrollbar-thumb {
@@ -43,6 +45,7 @@ code {
 	border: 1px solid transparent;
 	background-clip: content-box;
 	border-radius: 99px;
+	-webkit-app-region: no-drag;
 }
 
 ::-webkit-scrollbar-thumb:hover {


### PR DESCRIPTION
Add -webkit-app-region: no-drag to scrollbar pseudo-elements to allow clicking and dragging the scrollbar in borderless windows. Without this, the header's drag region prevented scrollbar interaction on linux.