### PR TITLE
Fix visible artefacts when resizing the annot window (Windows)

### DIFF
--- a/src-tauri/src/config.rs
+++ b/src-tauri/src/config.rs
@@ -22,6 +22,21 @@ pub enum Theme {
     Dark,
 }
 
+/// Native window/webview background color matching the frontend's `--bg-main`.
+/// Set on every window builder so WebView2 (Windows) paints a solid background
+/// before content renders — otherwise its default white shows as a flash on
+/// window-open and as a blank strip at the growing edges during live resize.
+///
+/// System resolves to light: dark mode is an opt-in `[data-theme="dark"]`
+/// override, so light is today's effective default. Light `--bg-main` is
+/// `#fafaf9`; dark is `#1d1b16`.
+pub fn window_background_color(theme: Theme) -> tauri::webview::Color {
+    match theme {
+        Theme::Dark => tauri::webview::Color(0x1d, 0x1b, 0x16, 0xff),
+        Theme::Light | Theme::System => tauri::webview::Color(0xfa, 0xfa, 0xf9, 0xff),
+    }
+}
+
 /// Application configuration stored in config.json.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Config {
@@ -609,6 +624,25 @@ mod tests {
     fn config_theme_defaults_to_system() {
         let config = Config::default();
         assert_eq!(config.theme, Theme::System);
+    }
+
+    #[test]
+    fn window_background_matches_css_bg_main() {
+        // Must match `--bg-main` in src/styles/tokens.css, or WebView2 flashes
+        // its default background on open/resize. System resolves to light
+        // because dark is an opt-in [data-theme="dark"] override.
+        assert_eq!(
+            window_background_color(Theme::Light),
+            tauri::webview::Color(0xfa, 0xfa, 0xf9, 0xff)
+        );
+        assert_eq!(
+            window_background_color(Theme::System),
+            window_background_color(Theme::Light)
+        );
+        assert_eq!(
+            window_background_color(Theme::Dark),
+            tauri::webview::Color(0x1d, 0x1b, 0x16, 0xff)
+        );
     }
 
     #[test]

--- a/src-tauri/src/config.rs
+++ b/src-tauri/src/config.rs
@@ -22,14 +22,17 @@ pub enum Theme {
     Dark,
 }
 
-/// Native window/webview background color matching the frontend's `--bg-main`.
-/// Set on every window builder so WebView2 (Windows) paints a solid background
-/// before content renders — otherwise its default white shows as a flash on
-/// window-open and as a blank strip at the growing edges during live resize.
+/// Native webview background color matching the frontend's `--bg-main`.
+/// Windows-only: WebView2 paints its default white before content renders,
+/// which flashes on window-open and shows as a blank strip at the growing
+/// edges during live resize. macOS ignores `background_color` (Tauri no-op)
+/// and Linux/WebKitGTK never had the flash, so this is gated to Windows at the
+/// call sites.
 ///
 /// System resolves to light: dark mode is an opt-in `[data-theme="dark"]`
 /// override, so light is today's effective default. Light `--bg-main` is
 /// `#fafaf9`; dark is `#1d1b16`.
+#[cfg(windows)]
 pub fn window_background_color(theme: Theme) -> tauri::webview::Color {
     match theme {
         Theme::Dark => tauri::webview::Color(0x1d, 0x1b, 0x16, 0xff),
@@ -626,6 +629,7 @@ mod tests {
         assert_eq!(config.theme, Theme::System);
     }
 
+    #[cfg(windows)]
     #[test]
     fn window_background_matches_css_bg_main() {
         // Must match `--bg-main` in src/styles/tokens.css, or WebView2 flashes

--- a/src-tauri/src/excalidraw_window.rs
+++ b/src-tauri/src/excalidraw_window.rs
@@ -152,6 +152,9 @@ pub async fn open_excalidraw_window(
                 .title("Excalidraw")
                 .inner_size(width, height)
                 .min_inner_size(600.0, 400.0)
+                .background_color(crate::config::window_background_color(
+                    crate::config::load_config().theme,
+                ))
                 .visible(false);
         #[cfg(target_os = "macos")]
         let b = b

--- a/src-tauri/src/excalidraw_window.rs
+++ b/src-tauri/src/excalidraw_window.rs
@@ -152,10 +152,12 @@ pub async fn open_excalidraw_window(
                 .title("Excalidraw")
                 .inner_size(width, height)
                 .min_inner_size(600.0, 400.0)
-                .background_color(crate::config::window_background_color(
-                    crate::config::load_config().theme,
-                ))
                 .visible(false);
+        // Windows-only: solid themed bg so WebView2 doesn't flash white.
+        #[cfg(windows)]
+        let b = b.background_color(crate::config::window_background_color(
+            crate::config::load_config().theme,
+        ));
         #[cfg(target_os = "macos")]
         let b = b
             .title_bar_style(tauri::TitleBarStyle::Overlay)

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -137,8 +137,13 @@ pub fn run(state: AppState, context: tauri::Context, json_output: bool) {
                 )
                 .title("annot")
                 .inner_size(1000.0, 700.0)
-                .background_color(config::window_background_color(config::load_config().theme))
-                .visible(false); // Will be shown after content loads
+                // Will be shown after content loads.
+                .visible(false);
+                // Windows-only: paint a solid themed bg so WebView2 doesn't
+                // flash its default white on open/resize (see config helper).
+                #[cfg(windows)]
+                let b = b
+                    .background_color(config::window_background_color(config::load_config().theme));
                 #[cfg(target_os = "macos")]
                 let b = b
                     .title_bar_style(tauri::TitleBarStyle::Overlay)

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -137,6 +137,7 @@ pub fn run(state: AppState, context: tauri::Context, json_output: bool) {
                 )
                 .title("annot")
                 .inner_size(1000.0, 700.0)
+                .background_color(config::window_background_color(config::load_config().theme))
                 .visible(false); // Will be shown after content loads
                 #[cfg(target_os = "macos")]
                 let b = b

--- a/src-tauri/src/mcp/mod.rs
+++ b/src-tauri/src/mcp/mod.rs
@@ -308,6 +308,9 @@ fn run_session_with_state(
             )
             .title("annot")
             .inner_size(1000.0, 700.0)
+            .background_color(crate::config::window_background_color(
+                crate::config::load_config().theme,
+            ))
             .visible(false); // Will be shown after content loads
             #[cfg(target_os = "macos")]
             let b = b

--- a/src-tauri/src/mcp/mod.rs
+++ b/src-tauri/src/mcp/mod.rs
@@ -308,10 +308,13 @@ fn run_session_with_state(
             )
             .title("annot")
             .inner_size(1000.0, 700.0)
-            .background_color(crate::config::window_background_color(
+            // Will be shown after content loads.
+            .visible(false);
+            // Windows-only: solid themed bg so WebView2 doesn't flash white.
+            #[cfg(windows)]
+            let b = b.background_color(crate::config::window_background_color(
                 crate::config::load_config().theme,
-            ))
-            .visible(false); // Will be shown after content loads
+            ));
             #[cfg(target_os = "macos")]
             let b = b
                 .title_bar_style(tauri::TitleBarStyle::Overlay)

--- a/src-tauri/src/mermaid_window.rs
+++ b/src-tauri/src/mermaid_window.rs
@@ -106,10 +106,12 @@ pub async fn open_mermaid_window(
             .title(format!("{}:{}-{}", filename, start_line, end_line))
             .inner_size(600.0, 500.0)
             .min_inner_size(300.0, 200.0)
-            .background_color(crate::config::window_background_color(
-                crate::config::load_config().theme,
-            ))
             .visible(false);
+        // Windows-only: solid themed bg so WebView2 doesn't flash white.
+        #[cfg(windows)]
+        let b = b.background_color(crate::config::window_background_color(
+            crate::config::load_config().theme,
+        ));
         #[cfg(target_os = "macos")]
         let b = b
             .title_bar_style(tauri::TitleBarStyle::Overlay)

--- a/src-tauri/src/mermaid_window.rs
+++ b/src-tauri/src/mermaid_window.rs
@@ -106,6 +106,9 @@ pub async fn open_mermaid_window(
             .title(format!("{}:{}-{}", filename, start_line, end_line))
             .inner_size(600.0, 500.0)
             .min_inner_size(300.0, 200.0)
+            .background_color(crate::config::window_background_color(
+                crate::config::load_config().theme,
+            ))
             .visible(false);
         #[cfg(target_os = "macos")]
         let b = b

--- a/src/lib/AnnotationEditor.svelte
+++ b/src/lib/AnnotationEditor.svelte
@@ -108,13 +108,14 @@
     annotationEntries?: Record<string, AnnotationEntry>;
     allowsImagePaste?: boolean;
     onImagePasteBlocked?: () => void;
+    onFileRefCopied?: (path: string) => void;
     onRequestCreateTag?: (text: string, from: number, to: number) => void;
     pendingTagInsertion?: { from: number; to: number; tag: Tag } | null;
     annotationId?: string; // Annotation id (saved entry or draft); '' for the session editor
     getOriginalLines?: () => string; // Returns original lines content for /replace
   }
 
-  let { content, onUpdate, sealed = false, onUnseal, onDismiss, tags = [], annotationEntries = {}, allowsImagePaste = false, onImagePasteBlocked, onRequestCreateTag, pendingTagInsertion, annotationId = '', getOriginalLines }: Props = $props();
+  let { content, onUpdate, sealed = false, onUnseal, onDismiss, tags = [], annotationEntries = {}, allowsImagePaste = false, onImagePasteBlocked, onFileRefCopied, onRequestCreateTag, pendingTagInsertion, annotationId = '', getOriginalLines }: Props = $props();
 
   // Get zoom level from context for floating elements
   const ctx = getAnnotContext();
@@ -341,8 +342,14 @@
       openExcalidrawEdit(detail.nodeId, detail.elements);
     };
 
+    const handleFileRefCopied = (e: Event) => {
+      const detail = (e as CustomEvent).detail as { path: string };
+      onFileRefCopied?.(detail.path);
+    };
+
     element?.addEventListener('excalidraw-create', handleExcalidrawCreate);
     element?.addEventListener('excalidraw-edit', handleExcalidrawEdit);
+    element?.addEventListener('file-ref-copied', handleFileRefCopied);
 
     // Listen for placeholder destruction (dispatched on document)
     document.addEventListener('excalidraw-placeholder-destroyed', handlePlaceholderDestroyed);
@@ -392,6 +399,7 @@
     return () => {
       element?.removeEventListener('excalidraw-create', handleExcalidrawCreate);
       element?.removeEventListener('excalidraw-edit', handleExcalidrawEdit);
+      element?.removeEventListener('file-ref-copied', handleFileRefCopied);
       document.removeEventListener('excalidraw-placeholder-destroyed', handlePlaceholderDestroyed);
     };
   });

--- a/src/lib/components/AnnotationSlot.svelte
+++ b/src/lib/components/AnnotationSlot.svelte
@@ -18,6 +18,7 @@
     onDismiss: () => void;
     onRequestCreateTag: (id: string, text: string, from: number, to: number) => void;
     onImagePasteBlocked: () => void;
+    onFileRefCopied?: (path: string) => void;
   }
 </script>
 
@@ -44,6 +45,7 @@
     onDismiss,
     onRequestCreateTag,
     onImagePasteBlocked,
+    onFileRefCopied,
   }: AnnotationSlotProps = $props();
 
   const ctx = getAnnotContext();
@@ -68,6 +70,7 @@
       annotationEntries={ctx.annotations.allEntries()}
       allowsImagePaste={ctx.allowsImagePaste}
       {onImagePasteBlocked}
+      {onFileRefCopied}
       onRequestCreateTag={(text, from, to) => onRequestCreateTag(s.id, text, from, to)}
       pendingTagInsertion={pendingTagInsertion?.editorKey === s.id
         ? { from: pendingTagInsertion.from, to: pendingTagInsertion.to, tag: pendingTagInsertion.tag }

--- a/src/lib/components/SessionEditor.svelte
+++ b/src/lib/components/SessionEditor.svelte
@@ -16,6 +16,7 @@
     onClose: () => void;
     onRequestCreateTag: (text: string, from: number, to: number) => void;
     onImagePasteBlocked: () => void;
+    onFileRefCopied?: (path: string) => void;
   }
 
   let {
@@ -26,7 +27,8 @@
     onOpen,
     onClose,
     onRequestCreateTag,
-    onImagePasteBlocked
+    onImagePasteBlocked,
+    onFileRefCopied
   }: Props = $props();
 
   const ctx = getAnnotContext();
@@ -44,6 +46,7 @@
       annotationEntries={ctx.annotations.allEntries()}
       allowsImagePaste={ctx.allowsImagePaste}
       {onImagePasteBlocked}
+      {onFileRefCopied}
       {onRequestCreateTag}
       {pendingTagInsertion}
     />

--- a/src/lib/tiptap/nodeviews/FileRefChip.svelte
+++ b/src/lib/tiptap/nodeviews/FileRefChip.svelte
@@ -11,13 +11,16 @@
 		return parts.length > 1 ? parts[parts.length - 2] : null;
 	});
 
+	let chipEl: HTMLSpanElement;
+
 	async function copyPath() {
 		await navigator.clipboard.writeText(path);
-		// TODO: show toast via event
+		chipEl?.dispatchEvent(new CustomEvent('file-ref-copied', { bubbles: true, detail: { path } }));
 	}
 </script>
 
 <span
+	bind:this={chipEl}
 	class="file-ref-chip"
 	title={path}
 	onclick={copyPath}

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -2,7 +2,7 @@
   import { invoke } from "@tauri-apps/api/core";
   import { listen, emit } from "@tauri-apps/api/event";
   import { getCurrentWindow } from "@tauri-apps/api/window";
-  import { onMount, tick } from "svelte";
+  import { onMount, onDestroy, tick } from "svelte";
   import type { ContentResponse, ContentNode, ContentMetadata, DiffDocument, Line, JSONContent, ExitMode, Tag, MarkdownMetadata, SectionInfo, ConfigSnapshot } from "$lib/types";
   import { getLineNumber, isSelectable, isPortalLine, isCodeBlockLine, isCodeBlockFence, isTableLine, isHorizontalRule } from "$lib/line-utils";
   import { type Range } from "$lib/range";
@@ -90,6 +90,31 @@
 
   // File tree sidebar (composable) — diff mode only
   const fileTree = useFileTree();
+
+  // While the window is GROWING, suspend rendering of the content tree
+  // (content-visibility: hidden via the `.resizing` class). On a 10k-line file
+  // the reflow can't fill the newly-exposed area fast enough, so content
+  // visibly trails the growing edge; freezing the last-painted frame until the
+  // drag settles hides that entirely.
+  //
+  // Only on grow, not shrink: shrinking has no trailing edge (existing content
+  // already covers the smaller window), and freezing a fast shrink outran the
+  // browser's cached paint and flashed blank. Live content on shrink is fine.
+  //
+  // No per-frame resize signal exists, so we debounce: set on a resize that
+  // grew either dimension, clear ~120ms after the last resize event.
+  let resizing = $state(false);
+  let resizeTimer: number | null = null;
+  let lastW = globalThis.innerWidth;
+  let lastH = globalThis.innerHeight;
+  function handleWindowResize() {
+    const grew = globalThis.innerWidth > lastW || globalThis.innerHeight > lastH;
+    lastW = globalThis.innerWidth;
+    lastH = globalThis.innerHeight;
+    if (grew && !resizing) resizing = true;
+    if (resizeTimer) clearTimeout(resizeTimer);
+    resizeTimer = window.setTimeout(() => { resizing = false; resizeTimer = null; }, 120);
+  }
 
   // Current file/hunk derived from indices (diff mode)
   let currentFile = $derived(diffDisplay?.docs[contentTracking.currentFileIndex] ?? null);
@@ -728,6 +753,8 @@
   onMount(async () => {
     const window = getCurrentWindow();
 
+    globalThis.addEventListener('resize', handleWindowResize);
+
     // Apply theme before any content renders (prevents flash)
     await initTheme();
 
@@ -827,6 +854,11 @@
       }
     });
   });
+
+  onDestroy(() => {
+    globalThis.removeEventListener('resize', handleWindowResize);
+    if (resizeTimer) clearTimeout(resizeTimer);
+  });
 </script>
 
 <svelte:window onkeydown={keyboard.handleKeyDown} onkeyup={keyboard.handleKeyUp} />
@@ -899,6 +931,7 @@
     <Pane order={2} class="content-pane">
     <div
       class="content"
+      class:resizing={resizing}
       class:shift-held={interaction.isShiftHeld}
       class:phase-idle={interaction.phase === 'idle'}
       class:phase-selecting={interaction.phase === 'selecting'}

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -2,7 +2,7 @@
   import { invoke } from "@tauri-apps/api/core";
   import { listen, emit } from "@tauri-apps/api/event";
   import { getCurrentWindow } from "@tauri-apps/api/window";
-  import { onMount, onDestroy, tick } from "svelte";
+  import { onMount, tick } from "svelte";
   import type { ContentResponse, ContentNode, ContentMetadata, DiffDocument, Line, JSONContent, ExitMode, Tag, MarkdownMetadata, SectionInfo, ConfigSnapshot } from "$lib/types";
   import { getLineNumber, isSelectable, isPortalLine, isCodeBlockLine, isCodeBlockFence, isTableLine, isHorizontalRule } from "$lib/line-utils";
   import { type Range } from "$lib/range";
@@ -753,8 +753,6 @@
   onMount(async () => {
     const window = getCurrentWindow();
 
-    globalThis.addEventListener('resize', handleWindowResize);
-
     // Apply theme before any content renders (prevents flash)
     await initTheme();
 
@@ -854,14 +852,9 @@
       }
     });
   });
-
-  onDestroy(() => {
-    globalThis.removeEventListener('resize', handleWindowResize);
-    if (resizeTimer) clearTimeout(resizeTimer);
-  });
 </script>
 
-<svelte:window onkeydown={keyboard.handleKeyDown} onkeyup={keyboard.handleKeyUp} />
+<svelte:window onkeydown={keyboard.handleKeyDown} onkeyup={keyboard.handleKeyUp} onresize={handleWindowResize} />
 
 <WindowResizeHandles />
 

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -582,6 +582,11 @@
     return true;
   }
 
+  function handleFileRefCopied(path: string) {
+    const alreadyShowing = toastMessage != null;
+    showToast(alreadyShowing ? `New copied path: "${path}"` : `Copied: "${path}"`);
+  }
+
   // Handle reporting a mermaid syntax error as an annotation
   async function handleReportMermaidError(displayRange: Range, errorMessage: string) {
     // Check if an annotation already spans exactly this range
@@ -705,6 +710,7 @@
     onDismiss: closeCurrentEditor,
     onRequestCreateTag: handleRequestCreateTag,
     onImagePasteBlocked: handleImagePasteBlocked,
+    onFileRefCopied: handleFileRefCopied,
   });
 
   // Keyboard handling (composable)
@@ -905,6 +911,7 @@
         onClose={closeSessionEditor}
         onRequestCreateTag={(text, from, to) => handleRequestCreateTag('session', text, from, to)}
         onImagePasteBlocked={handleImagePasteBlocked}
+        onFileRefCopied={handleFileRefCopied}
       />
     </div>
   </div>

--- a/src/styles/components/code-viewer.css
+++ b/src/styles/components/code-viewer.css
@@ -122,6 +122,25 @@ header.header {
 	transform-origin: top left;
 }
 
+/* While the window is GROWING, suspend rendering of the content tree. On a
+   10k-line file the reflow can't fill the newly-exposed area fast enough so
+   content visibly trails the growing edge; content-visibility: hidden skips
+   layout/paint/style for the whole subtree (~7x cheaper per frame, measured)
+   and keeps the last-painted frame. The `.resizing` class is set on a grow
+   and cleared ~120ms after the last resize event (see +page.svelte); shrink
+   stays live (freezing it flashed blank on fast drags).
+
+   We hide the inner (whose frozen width can't fill a grown window) but keep the
+   outer scroller `.content` at full flex size with a solid themed background,
+   so growing shows themed empty space — not a stale scrollbar or torn content
+   — and the real content snaps back in on release. */
+.content.resizing {
+	background: var(--bg-main);
+}
+.content.resizing .content-inner {
+	content-visibility: hidden;
+}
+
 /* Code lines - use div.line to avoid matching syntect's .line class on spans */
 div.line {
 	position: relative;
@@ -129,12 +148,16 @@ div.line {
 	white-space: pre-wrap;
 	tab-size: 4;
 	/* Skip layout/paint for off-screen lines. On large files (10k+ lines) a
-	   window resize otherwise re-wraps every line every frame, so content and
-	   the bottom status bar visibly trail the resize. content-visibility lets
-	   the engine skip off-screen rows; contain-intrinsic-size keeps their
-	   reserved height stable so the scrollbar doesn't jump. */
+	   window resize otherwise re-wraps every line every frame, so content
+	   visibly trails the resize. content-visibility lets the engine skip
+	   off-screen rows; contain-intrinsic-size keeps their reserved height
+	   stable so the scrollbar doesn't jump. (Continuous resize is handled
+	   separately by the `.resizing` freeze above.) */
 	content-visibility: auto;
-	contain-intrinsic-size: auto 1.5em;
+	/* Match the real single-row line-height (.code/.gutter = 22px) so the
+	   reserved height for never-yet-rendered off-screen lines is accurate;
+	   `auto` then remembers each line's true (possibly wrapped) height. */
+	contain-intrinsic-size: auto 22px;
 }
 
 /* Hover highlight — CSS-driven so mouse-move never re-renders 10k lines.

--- a/src/styles/components/code-viewer.css
+++ b/src/styles/components/code-viewer.css
@@ -128,6 +128,13 @@ div.line {
 	display: flex;
 	white-space: pre-wrap;
 	tab-size: 4;
+	/* Skip layout/paint for off-screen lines. On large files (10k+ lines) a
+	   window resize otherwise re-wraps every line every frame, so content and
+	   the bottom status bar visibly trail the resize. content-visibility lets
+	   the engine skip off-screen rows; contain-intrinsic-size keeps their
+	   reserved height stable so the scrollbar doesn't jump. */
+	content-visibility: auto;
+	contain-intrinsic-size: auto 1.5em;
 }
 
 /* Hover highlight — CSS-driven so mouse-move never re-renders 10k lines.

--- a/src/styles/components/status-bar.css
+++ b/src/styles/components/status-bar.css
@@ -9,9 +9,11 @@
 	justify-content: space-between;
 	gap: 24px;
 	padding: 6px 16px;
+	/* Background is opaque (bg-main has no alpha), so a backdrop-filter blurs
+	   pixels that are then fully painted over — zero visual effect, but a
+	   full-width blur pass every resize frame that made the status bar visibly
+	   trail the window edge. Dropped it. */
 	background: color-mix(in srgb, var(--mode-color, var(--bg-main)) 15%, var(--bg-main));
-	backdrop-filter: blur(16px) saturate(150%);
-	-webkit-backdrop-filter: blur(16px) saturate(150%);
 	border-top: 1px solid color-mix(in srgb, var(--mode-color, transparent) 20%, rgba(0, 0, 0, 0.06));
 	font-size: 12px;
 	z-index: 10;


### PR DESCRIPTION
Problem

On the Windows build, resizing the window showed visible artefacts: a white flash on open, and — most noticeably on large files — content (text, syntax highlighting, and the bottom status bar) that visibly trailed the window edge during a drag, failing to repaint fast enough to keep up.

Fix 
- Windows webview background_color matching the theme's --bg-main, so WebView2 paints a solid themed background immediately instead of white. Gated to #[cfg(windows)] — macOS ignores the API and Linux never had the flash.
- Grow-only content freeze: while the window is growing, a .resizing class applies content-visibility: hidden to the content tree (~7× cheaper per frame, measured), freezing the last-painted frame; the newly-exposed area shows clean themed space and content snaps back ~120ms after the drag settles. Shrinking stays live — it has no trailing edge, and freezing a fast shrink flashed blank.
- Removed the status bar's backdrop-filter — its background is opaque, so the blur had zero visual effect but cost a full-width blur pass every frame.
- Minor: content-visibility: auto + accurate contain-intrinsic-size: 22px on line rows for smooth off-screen skipping.
- Feat: show toast when copying @ file reference