### PR TITLE
feat(diff): file tree sidebar + palette fuzzy-jump

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,6 @@ src-tauri/gen/schemas
 
 # Excalidraw fonts (copied from node_modules at install time)
 static/excalidraw-assets/fonts/
+
+# Local-only working files (specs, scratch)
+*.local

--- a/docs/features.md
+++ b/docs/features.md
@@ -25,6 +25,8 @@ Open any source file for annotation. Syntax highlighting adapts to language. Nav
 ### Diff Review
 Review git changes (`--staged`, `main...HEAD`) or raw unified diffs. Color-coded: additions green, deletions red. Annotations capture both old and new line numbers.
 
+**File tree** — `Cmd+B` toggles a sidebar listing every changed file with its +/− counts. Clicking a file scrolls to it; the row for the file currently in view stays highlighted. The `:` palette's **Files** namespace does the same jump by fuzzy search.
+
 ### Content Review
 Review agent-generated content — plans, drafts, analysis. Markdown rendering with Mermaid diagrams and portal links that embed live code.
 
@@ -125,7 +127,7 @@ Press `Shift+C` to add a high-level comment that applies to the entire review (n
 
 ## Command Palette (`:`)
 
-Press `:` (colon) to open. Seven namespaces:
+Press `:` (colon) to open. Eight namespaces:
 
 ### Tags
 - Browse, create, edit, delete tags
@@ -137,6 +139,9 @@ Press `:` (colon) to open. Seven namespaces:
 - Examples: Apply, Revise, Reject, Discuss
 - Press `s` to set as active
 - Press `r` to reorder (drag with arrow keys)
+
+### Files
+- Fuzzy-jump to a changed file (diff review only)
 
 ### Copy
 - Copy content only
@@ -169,6 +174,7 @@ Press `:` (colon) to open. Seven namespaces:
 | `:` | Command palette |
 | `Alt+Tab` | Command palette → Exit modes |
 | Ctrl+F | Search |
+| `Cmd+B` | Toggle file tree (diffs) |
 | `e` | Edit item (in command palette) |
 | `r` | Reorder items (exit modes only) |
 | `Cmd+D` | Delete item (in command palette) |

--- a/src/lib/CommandPalette/CommandPalette.svelte
+++ b/src/lib/CommandPalette/CommandPalette.svelte
@@ -4,10 +4,11 @@
   import { invoke } from '@tauri-apps/api/core';
   import { openUrl } from '@tauri-apps/plugin-opener';
   import { reduce, computeItemList } from './engine/reducer';
-  import { createQueryContext, setTagItems, setExitModeItems, saveTagItem, deleteTagItem, saveExitModeItem, deleteExitModeItem, reorderExitModeItems, generateTagId, generateExitModeId, setObsidianVaults, saveObsidianVault, deleteObsidianVault, getVaultNames, generateVaultId } from './namespaces';
+  import { createQueryContext, setTagItems, setExitModeItems, setFileItems, saveTagItem, deleteTagItem, saveExitModeItem, deleteExitModeItem, reorderExitModeItems, generateTagId, generateExitModeId, setObsidianVaults, saveObsidianVault, deleteObsidianVault, getVaultNames, generateVaultId } from './namespaces';
   import type { State, Action, Command, Item, Namespace, InitialState } from './engine/types';
   import { getFilterPlaceholder, canDelete, isItemEditable } from './engine/types';
   import type { Tag, ExitMode } from '$lib/types';
+  import type { FileEntry } from '$lib/file-tree';
   import Icon from './Icon.svelte';
 
   // Config type matching Rust
@@ -20,6 +21,7 @@
   interface Props {
     tags: Tag[];
     exitModes: ExitMode[];
+    files?: FileEntry[];
     zoomLevel?: number;
     onClose: () => void;
     onSetExitMode: (modeId: string) => void;
@@ -32,7 +34,7 @@
     onEvent?: (event: string, payload: unknown) => void;
   }
 
-  let { tags, exitModes, zoomLevel = 1, onClose, onSetExitMode, onTagsChange, onExitModesChange, showToast, onOpenSaveModal, initialState, onItemCreated, onEvent }: Props = $props();
+  let { tags, exitModes, files = [], zoomLevel = 1, onClose, onSetExitMode, onTagsChange, onExitModesChange, showToast, onOpenSaveModal, initialState, onItemCreated, onEvent }: Props = $props();
 
   // Convert domain types to Item format
   function tagToItem(tag: Tag): Item {
@@ -65,6 +67,10 @@
 
   $effect(() => {
     setExitModeItems(exitModes.map(exitModeToItem));
+  });
+
+  $effect(() => {
+    setFileItems(files);
   });
 
   // State machine

--- a/src/lib/CommandPalette/Icon.svelte
+++ b/src/lib/CommandPalette/Icon.svelte
@@ -22,7 +22,8 @@
     ChatBubbleIcon,
     HeadingH1Icon,
     HeadingH2Icon,
-    HeadingH3Icon
+    HeadingH3Icon,
+    FileIcon
   } from '$lib/icons';
 
   interface Props {
@@ -55,7 +56,8 @@
     'chat-bubble': ChatBubbleIcon,
     'heading-h1': HeadingH1Icon,
     'heading-h2': HeadingH2Icon,
-    'heading-h3': HeadingH3Icon
+    'heading-h3': HeadingH3Icon,
+    file: FileIcon
   };
 
   const IconComponent = $derived(icons[name]);

--- a/src/lib/CommandPalette/namespaces/files.test.ts
+++ b/src/lib/CommandPalette/namespaces/files.test.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { setFileItems, getFileItems, filterFileItems } from './files';
+import { createQueryContext } from './index';
+import type { FileEntry } from '$lib/file-tree';
+
+function entry(index: number, path: string, startLine: number): FileEntry {
+  const slash = path.lastIndexOf('/');
+  return {
+    index,
+    path,
+    dir: path.slice(0, slash + 1),
+    name: path.slice(slash + 1),
+    added: 1,
+    deleted: 0,
+    startLine,
+  };
+}
+
+describe('files namespace', () => {
+  beforeEach(() => {
+    setFileItems([]);
+  });
+
+  it('turns each file into a jump action carrying its display index', () => {
+    setFileItems([entry(0, 'src/lib/types.ts', 12)]);
+
+    expect(getFileItems()[0]).toMatchObject({
+      id: 'file-0',
+      name: 'src/lib/types.ts',
+      action: { type: 'EMIT_EVENT', event: 'JUMP_TO_FILE', payload: 12 },
+    });
+  });
+
+  it('fuzzy-matches on the full path', () => {
+    setFileItems([entry(0, 'src/lib/types.ts', 1), entry(1, 'src-tauri/src/diff.rs', 40)]);
+
+    expect(filterFileItems('lib/typ').map((i) => i.name)).toEqual(['src/lib/types.ts']);
+  });
+
+  it('is hidden from the palette when there are no files', () => {
+    expect(createQueryContext().namespaces.map((n) => n.id)).not.toContain('files');
+
+    setFileItems([entry(0, 'a.ts', 1)]);
+
+    expect(createQueryContext().namespaces.map((n) => n.id)).toContain('files');
+  });
+});

--- a/src/lib/CommandPalette/namespaces/files.ts
+++ b/src/lib/CommandPalette/namespaces/files.ts
@@ -1,0 +1,37 @@
+// Files namespace for CommandPalette
+// Action-only namespace — items jump the viewport to a file in the diff
+
+import type { Namespace, Item } from '../engine/types';
+import type { FileEntry } from '$lib/file-tree';
+import { fuzzySearch } from '$lib/fuzzy';
+import { SimpleItem } from '../items';
+
+export const filesNamespace: Namespace = {
+  id: 'files',
+  label: 'Files',
+  icon: 'file',
+  ItemComponent: SimpleItem,
+  fields: [],
+  hotkeys: [],
+  capabilities: { delete: false },
+};
+
+// Seeded from the session's diff metadata; empty for non-diff content
+let fileItems: Item[] = [];
+
+export function setFileItems(entries: FileEntry[]): void {
+  fileItems = entries.map((entry) => ({
+    id: `file-${entry.index}`,
+    name: entry.path,
+    values: {},
+    action: { type: 'EMIT_EVENT' as const, event: 'JUMP_TO_FILE', payload: entry.startLine },
+  }));
+}
+
+export function getFileItems(): Item[] {
+  return fileItems;
+}
+
+export function filterFileItems(query: string): Item[] {
+  return fuzzySearch(fileItems, query, [{ name: 'name', weight: 1 }]);
+}

--- a/src/lib/CommandPalette/namespaces/index.ts
+++ b/src/lib/CommandPalette/namespaces/index.ts
@@ -8,11 +8,13 @@ import { copyNamespace, getCopyItems, filterCopyItems } from './copy';
 import { saveNamespace, getSaveItems, filterSaveItems } from './save';
 import { obsidianNamespace, getObsidianItems, filterObsidianItems } from './obsidian';
 import { themeNamespace, getThemeItems, filterThemeItems } from './theme';
+import { filesNamespace, getFileItems, filterFileItems } from './files';
 
-const namespaces: Namespace[] = [tagsNamespace, exitModesNamespace, copyNamespace, obsidianNamespace, saveNamespace, themeNamespace];
+const namespaces: Namespace[] = [tagsNamespace, exitModesNamespace, filesNamespace, copyNamespace, obsidianNamespace, saveNamespace, themeNamespace];
 
 const getItemsMap: Record<string, () => Item[]> = {
   tags: getTagItems,
+  files: getFileItems,
   'exit-modes': getExitModeItems,
   copy: getCopyItems,
   save: getSaveItems,
@@ -22,6 +24,7 @@ const getItemsMap: Record<string, () => Item[]> = {
 
 const filterItemsMap: Record<string, (query: string) => Item[]> = {
   tags: filterTagItems,
+  files: filterFileItems,
   'exit-modes': filterExitModeItems,
   copy: filterCopyItems,
   save: filterSaveItems,
@@ -29,12 +32,20 @@ const filterItemsMap: Record<string, (query: string) => Item[]> = {
   theme: filterThemeItems,
 };
 
+/** Files only exist in diff sessions — don't surface an empty namespace elsewhere. */
+function activeNamespaces(): Namespace[] {
+  return namespaces.filter((n) => n.id !== 'files' || getFileItems().length > 0);
+}
+
 export function createQueryContext(): QueryContext {
   return {
-    namespaces,
+    // Getter, not a snapshot: items are seeded after this context is built.
+    get namespaces() {
+      return activeNamespaces();
+    },
 
     filterNamespaces(query: string): Namespace[] {
-      return fuzzySearch(namespaces, query, [{ name: 'label', weight: 1 }]);
+      return fuzzySearch(activeNamespaces(), query, [{ name: 'label', weight: 1 }]);
     },
 
     getItems(namespace: Namespace) {
@@ -54,3 +65,4 @@ export { copyNamespace, getCopyItems, filterCopyItems } from './copy';
 export { saveNamespace, getSaveItems, filterSaveItems } from './save';
 export { obsidianNamespace, getObsidianItems, filterObsidianItems, setObsidianVaults, saveObsidianVault, deleteObsidianVault, getVaultNames, generateVaultId, getRawVaultItems } from './obsidian';
 export { themeNamespace, getThemeItems, filterThemeItems } from './theme';
+export { filesNamespace, getFileItems, setFileItems, filterFileItems } from './files';

--- a/src/lib/HelpOverlay.svelte
+++ b/src/lib/HelpOverlay.svelte
@@ -55,6 +55,7 @@
     {
       category: 'View',
       items: [
+        { keys: [keys.cmd, 'B'], description: 'Toggle file tree (diffs)' },
         { keys: [keys.cmd, '+'], description: 'Zoom in' },
         { keys: [keys.cmd, '-'], description: 'Zoom out' },
         { keys: [keys.cmd, '0'], description: 'Reset zoom' },

--- a/src/lib/components/FileTree.svelte
+++ b/src/lib/components/FileTree.svelte
@@ -1,0 +1,51 @@
+<script lang="ts">
+  import type { FileEntry } from '$lib/file-tree';
+
+  interface Props {
+    entries: FileEntry[];
+    currentIndex: number;
+    onJump: (startLine: number) => void;
+  }
+
+  let { entries, currentIndex, onJump }: Props = $props();
+
+  let totalAdded = $derived(entries.reduce((sum, e) => sum + e.added, 0));
+  let totalDeleted = $derived(entries.reduce((sum, e) => sum + e.deleted, 0));
+
+  function jump(e: MouseEvent, entry: FileEntry) {
+    onJump(entry.startLine);
+    // Give focus back to the window so line shortcuts (c, :, ?) keep working.
+    (e.currentTarget as HTMLButtonElement).blur();
+  }
+</script>
+
+<aside class="file-tree" aria-label="Changed files">
+  <div class="file-tree-summary">
+    <span>{entries.length} {entries.length === 1 ? 'file' : 'files'} changed</span>
+    <span class="file-tree-counts">
+      <span class="added">+{totalAdded}</span>
+      <span class="deleted">−{totalDeleted}</span>
+    </span>
+  </div>
+  <ul class="file-tree-list">
+    {#each entries as entry (entry.index)}
+      <li>
+        <button
+          class="file-row"
+          class:current={entry.index === currentIndex}
+          aria-current={entry.index === currentIndex ? 'true' : undefined}
+          title={entry.path}
+          onclick={(e) => jump(e, entry)}
+        >
+          <span class="file-row-path">
+            {#if entry.dir}<span class="file-row-dir">{entry.dir}</span>{/if}<span class="file-row-name">{entry.name}</span>
+          </span>
+          <span class="file-tree-counts">
+            {#if entry.added}<span class="added">+{entry.added}</span>{/if}
+            {#if entry.deleted}<span class="deleted">−{entry.deleted}</span>{/if}
+          </span>
+        </button>
+      </li>
+    {/each}
+  </ul>
+</aside>

--- a/src/lib/composables/useContentTracking.svelte.ts
+++ b/src/lib/composables/useContentTracking.svelte.ts
@@ -3,6 +3,10 @@ import type { DiffMetadata, MarkdownMetadata } from '$lib/types';
 
 export function useContentTracking() {
   let hunkTracker: ContentTracker<HunkPayload> | null = $state(null);
+  // Separate from hunkTracker: a file's header lines sit *before* its first hunk, so
+  // hunk boundaries alone resolve them to the previous file. hunkTracker stays
+  // hunk-only because useSelectionBounds walks its boundaries to clamp selections.
+  let fileTracker: ContentTracker<{ fileIndex: number }> | null = $state(null);
   let sectionTracker: ContentTracker<SectionPayload> | null = $state(null);
   let currentFileIndex = $state(0);
   let currentHunkIndex = $state(0);
@@ -21,6 +25,9 @@ export function useContentTracking() {
       }
     }
     hunkTracker = new ContentTracker(boundaries);
+    fileTracker = new ContentTracker(
+      meta.files.map((file, fileIndex) => ({ line: file.start_line, data: { fileIndex } })),
+    );
   }
 
   function initializeMarkdown(meta: MarkdownMetadata): void {
@@ -32,11 +39,21 @@ export function useContentTracking() {
   }
 
   function updateFromLine(lineNum: number): void {
+    if (fileTracker) {
+      const boundary = fileTracker.findAt(lineNum);
+      if (boundary) currentFileIndex = boundary.data.fileIndex;
+    }
     if (hunkTracker) {
       const boundary = hunkTracker.findAt(lineNum);
       if (boundary) {
-        currentFileIndex = boundary.data.fileIndex;
-        currentHunkIndex = boundary.data.hunkIndex;
+        if (!fileTracker) {
+          currentFileIndex = boundary.data.fileIndex;
+          currentHunkIndex = boundary.data.hunkIndex;
+        } else {
+          // A hunk belonging to another file means we're in this file's header,
+          // above its first hunk.
+          currentHunkIndex = boundary.data.fileIndex === currentFileIndex ? boundary.data.hunkIndex : 0;
+        }
       }
     }
     if (sectionTracker) {

--- a/src/lib/composables/useContentTracking.test.ts
+++ b/src/lib/composables/useContentTracking.test.ts
@@ -85,6 +85,53 @@ describe('useContentTracking', () => {
     expect(tracking.currentHunkIndex).toBe(1);
   });
 
+  it('resolves a file header line to its own file, not the file above it', () => {
+    const tracking = useContentTracking();
+    const meta: DiffMetadata = {
+      files: [
+        {
+          old_name: 'lib.rs',
+          new_name: 'lib.rs',
+          language: 'rust',
+          start_line: 1,
+          end_line: 20,
+          hunks: [
+            { display_line: 5, old_start: 1, old_count: 5, new_start: 1, new_count: 6, function_context: null, function_context_html: null },
+          ],
+        },
+        {
+          old_name: 'main.rs',
+          new_name: 'main.rs',
+          language: 'rust',
+          start_line: 21,
+          end_line: 40,
+          hunks: [
+            { display_line: 25, old_start: 1, old_count: 5, new_start: 1, new_count: 5, function_context: null, function_context_html: null },
+          ],
+        },
+      ],
+    };
+
+    flushSync(() => {
+      tracking.initializeDiff(meta);
+    });
+
+    // Line 21 is main.rs's `diff --git` header — it sits above main.rs's first hunk,
+    // so hunk boundaries alone would resolve it to lib.rs.
+    flushSync(() => {
+      tracking.updateFromLine(21);
+    });
+    expect(tracking.currentFileIndex).toBe(1);
+    expect(tracking.currentHunkIndex).toBe(0);
+
+    // Inside main.rs's hunk, tracking is unchanged.
+    flushSync(() => {
+      tracking.updateFromLine(30);
+    });
+    expect(tracking.currentFileIndex).toBe(1);
+    expect(tracking.currentHunkIndex).toBe(0);
+  });
+
   it('initializes markdown tracker from metadata', () => {
     const tracking = useContentTracking();
     const meta: MarkdownMetadata = {

--- a/src/lib/composables/useFileTree.svelte.ts
+++ b/src/lib/composables/useFileTree.svelte.ts
@@ -1,0 +1,11 @@
+/** Sidebar visibility. Hidden by default; not persisted across sessions. */
+export function useFileTree() {
+  let isOpen = $state(false);
+
+  return {
+    get isOpen() { return isOpen; },
+    toggle() { isOpen = !isOpen; },
+    open() { isOpen = true; },
+    close() { isOpen = false; },
+  };
+}

--- a/src/lib/composables/useKeyboard.svelte.ts
+++ b/src/lib/composables/useKeyboard.svelte.ts
@@ -16,6 +16,7 @@ export interface KeyboardHandlers {
   onZoomReset?: () => void;
   onCommentHoveredLine?: () => void;
   onSelectAllContent?: () => void;
+  onToggleFileTree?: () => void;
 }
 
 export interface KeyboardState {
@@ -127,6 +128,13 @@ export function useKeyboard(handlers: KeyboardHandlers, state: KeyboardState) {
     if (e.key === 'f' && (e.metaKey || e.ctrlKey) && !state.isSearchOpen() && !state.isEditorActive() && !state.isCommandPaletteOpen()) {
       e.preventDefault();
       handlers.onOpenSearch?.();
+      return;
+    }
+
+    // Cmd+B to toggle the file tree sidebar
+    if (e.key === 'b' && (e.metaKey || e.ctrlKey) && !e.altKey && !state.isEditorActive() && !state.isCommandPaletteOpen()) {
+      e.preventDefault();
+      handlers.onToggleFileTree?.();
       return;
     }
 

--- a/src/lib/composables/useKeyboard.test.ts
+++ b/src/lib/composables/useKeyboard.test.ts
@@ -216,4 +216,36 @@ describe('useKeyboard', () => {
 
     expect(onCommentHoveredLine).not.toHaveBeenCalled();
   });
+
+  it('calls onToggleFileTree on Cmd+B', () => {
+    const onToggleFileTree = vi.fn();
+    const keyboard = useKeyboard({ onToggleFileTree }, defaultState);
+
+    const event = createKeyboardEvent('b', { metaKey: true });
+    keyboard.handleKeyDown(event);
+
+    expect(event.preventDefault).toHaveBeenCalled();
+    expect(onToggleFileTree).toHaveBeenCalled();
+  });
+
+  it('does not toggle the file tree while an editor is active', () => {
+    const onToggleFileTree = vi.fn();
+    const keyboard = useKeyboard({ onToggleFileTree }, {
+      ...defaultState,
+      isEditorActive: () => true,
+    });
+
+    keyboard.handleKeyDown(createKeyboardEvent('b', { metaKey: true }));
+
+    expect(onToggleFileTree).not.toHaveBeenCalled();
+  });
+
+  it('does not toggle the file tree on a bare b', () => {
+    const onToggleFileTree = vi.fn();
+    const keyboard = useKeyboard({ onToggleFileTree }, defaultState);
+
+    keyboard.handleKeyDown(createKeyboardEvent('b'));
+
+    expect(onToggleFileTree).not.toHaveBeenCalled();
+  });
 });

--- a/src/lib/file-tree.test.ts
+++ b/src/lib/file-tree.test.ts
@@ -1,0 +1,73 @@
+import { describe, it, expect } from 'vitest';
+import { deriveFileEntries } from './file-tree';
+import type { DiffFileInfo, DiffMetadata, Line } from './types';
+
+function diffLine(kind: 'file_header' | 'added' | 'deleted' | 'context', path = 'a'): Line {
+  return {
+    content: '',
+    html: null,
+    origin: { type: 'diff', path, old_line: null, new_line: null },
+    semantics: { type: 'diff', kind },
+  };
+}
+
+function file(partial: Partial<DiffFileInfo>): DiffFileInfo {
+  return {
+    old_name: null,
+    new_name: null,
+    language: 'ts',
+    start_line: 1,
+    end_line: 1,
+    hunks: [],
+    ...partial,
+  };
+}
+
+describe('deriveFileEntries', () => {
+  it('returns [] without diff metadata', () => {
+    expect(deriveFileEntries([], null)).toEqual([]);
+  });
+
+  it('splits the path into a dimmable directory prefix and a basename', () => {
+    const meta: DiffMetadata = {
+      files: [
+        file({ new_name: 'src/lib/types.ts', start_line: 1, end_line: 1 }),
+        file({ new_name: 'README.md', start_line: 2, end_line: 2 }),
+      ],
+    };
+
+    const entries = deriveFileEntries([diffLine('file_header'), diffLine('file_header')], meta);
+
+    expect(entries[0]).toMatchObject({ path: 'src/lib/types.ts', dir: 'src/lib/', name: 'types.ts' });
+    expect(entries[1]).toMatchObject({ path: 'README.md', dir: '', name: 'README.md' });
+  });
+
+  it('falls back to old_name for deleted files', () => {
+    const meta: DiffMetadata = { files: [file({ old_name: 'gone.ts', new_name: null })] };
+
+    expect(deriveFileEntries([diffLine('file_header')], meta)[0].path).toBe('gone.ts');
+  });
+
+  it('counts added/deleted lines within each file range', () => {
+    // display: 1 header, 2 added, 3 deleted, 4 context | 5 header, 6 added
+    const lines = [
+      diffLine('file_header'),
+      diffLine('added'),
+      diffLine('deleted'),
+      diffLine('context'),
+      diffLine('file_header'),
+      diffLine('added'),
+    ];
+    const meta: DiffMetadata = {
+      files: [
+        file({ new_name: 'a.ts', start_line: 1, end_line: 4 }),
+        file({ new_name: 'b.ts', start_line: 5, end_line: 6 }),
+      ],
+    };
+
+    const entries = deriveFileEntries(lines, meta);
+
+    expect(entries[0]).toMatchObject({ index: 0, added: 1, deleted: 1, startLine: 1 });
+    expect(entries[1]).toMatchObject({ index: 1, added: 1, deleted: 0, startLine: 5 });
+  });
+});

--- a/src/lib/file-tree.ts
+++ b/src/lib/file-tree.ts
@@ -1,0 +1,47 @@
+import type { DiffMetadata, Line } from './types';
+import { getDiffKind } from './line-utils';
+
+/** A changed file in a diff, ready for display in the file tree / palette. */
+export interface FileEntry {
+  /** Index into DiffMetadata.files */
+  index: number;
+  /** Full path — new_name, falling back to old_name for deletions */
+  path: string;
+  /** Directory prefix, with trailing slash, or '' for root-level files */
+  dir: string;
+  /** Basename */
+  name: string;
+  added: number;
+  deleted: number;
+  /** Display index of the file header row */
+  startLine: number;
+}
+
+/**
+ * Derive the file list from diff metadata + rendered lines.
+ *
+ * The single place that binds navigation to the diff wire model — when the wire
+ * model becomes per-file documents, only this function moves.
+ */
+export function deriveFileEntries(lines: Line[], meta: DiffMetadata | null): FileEntry[] {
+  if (!meta) return [];
+
+  return meta.files.map((file, index) => {
+    const path = file.new_name ?? file.old_name ?? '';
+    const slash = path.lastIndexOf('/');
+
+    const kinds = lines
+      .slice(file.start_line - 1, file.end_line)
+      .map(getDiffKind);
+
+    return {
+      index,
+      path,
+      dir: path.slice(0, slash + 1),
+      name: path.slice(slash + 1),
+      added: kinds.filter((k) => k === 'added').length,
+      deleted: kinds.filter((k) => k === 'deleted').length,
+      startLine: file.start_line,
+    };
+  });
+}

--- a/src/lib/icons/FileIcon.svelte
+++ b/src/lib/icons/FileIcon.svelte
@@ -1,0 +1,10 @@
+<script lang="ts">
+  interface Props {
+    class?: string;
+  }
+  let { class: className = '' }: Props = $props();
+</script>
+
+<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="cp-icon {className}">
+  <path stroke-linecap="round" stroke-linejoin="round" d="M19.5 14.25v-2.625a3.375 3.375 0 0 0-3.375-3.375h-1.5A1.125 1.125 0 0 1 13.5 7.125v-1.5A3.375 3.375 0 0 0 10.125 2.25H8.25m2.25 0H5.625c-.621 0-1.125.504-1.125 1.125v17.25c0 .621.504 1.125 1.125 1.125h12.75c.621 0 1.125-.504 1.125-1.125V11.25a9 9 0 0 0-9-9Z" />
+</svg>

--- a/src/lib/icons/index.ts
+++ b/src/lib/icons/index.ts
@@ -25,3 +25,4 @@ export { default as ChatBubbleIcon } from './ChatBubbleIcon.svelte';
 export { default as HeadingH1Icon } from './HeadingH1Icon.svelte';
 export { default as HeadingH2Icon } from './HeadingH2Icon.svelte';
 export { default as HeadingH3Icon } from './HeadingH3Icon.svelte';
+export { default as FileIcon } from './FileIcon.svelte';

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -18,6 +18,9 @@
   import Table from "$lib/components/embedded/Table.svelte";
   import RegularLines from "$lib/components/embedded/RegularLines.svelte";
   import { Header, StatusBar, SessionEditor, WindowResizeHandles } from "$lib/components";
+  import FileTree from "$lib/components/FileTree.svelte";
+  import { deriveFileEntries } from "$lib/file-tree";
+  import { useFileTree } from "$lib/composables/useFileTree.svelte";
   import { useExitModes } from "$lib/composables/useExitModes.svelte";
   import { useContentTracking } from "$lib/composables/useContentTracking.svelte";
   import { useInteraction } from "$lib/composables/useInteraction.svelte";
@@ -80,6 +83,10 @@
   const contentTracking = useContentTracking();
   let contentEl: HTMLDivElement | null = $state(null);
   let scrollRafId: number | null = null;
+
+  // File tree sidebar (composable) — diff mode only
+  const fileTree = useFileTree();
+  let fileEntries = $derived(deriveFileEntries(lines, diffMetadata));
 
   // Current file/hunk derived from indices (diff mode)
   let currentFile = $derived.by(() => {
@@ -191,10 +198,16 @@
   const lineSegmentation = useLineSegments(() => lines);
 
   // Search (composable)
-  function scrollToDisplayIndex(displayIndex: number) {
+  function scrollToDisplayIndex(displayIndex: number, block: ScrollLogicalPosition = 'center') {
     contentEl
       ?.querySelector(`[data-display-idx="${displayIndex}"]`)
-      ?.scrollIntoView({ block: 'center' });
+      ?.scrollIntoView({ block });
+  }
+
+  // File jumps land the file header at the top of the viewport. Centering it would
+  // leave the *previous* file at the top, which is what current-file tracking reads.
+  function jumpToFile(startLine: number) {
+    scrollToDisplayIndex(startLine, 'start');
   }
   const search = useSearch(() => lines, scrollToDisplayIndex);
 
@@ -376,6 +389,9 @@
     if (event === 'SET_THEME') {
       setTheme(payload as ThemePreference);
       overlay.close();
+    } else if (event === 'JUMP_TO_FILE') {
+      overlay.close();
+      jumpToFile(payload as number);
     }
   }
 
@@ -575,6 +591,7 @@
       onCloseWindow: () => getCurrentWindow().close(),
       onOpenSearch: () => search.open(),
       onOpenHelp: () => overlay.openHelp(),
+      onToggleFileTree: () => { if (diffMetadata) fileTree.toggle(); },
       onZoomIn: () => contentZoom = Math.min(contentZoom + 0.1, 3.0),
       onZoomOut: () => contentZoom = Math.max(contentZoom - 0.1, 0.5),
       onZoomReset: () => contentZoom = 1.0,
@@ -752,6 +769,15 @@
     </div>
   </div>
 
+  <div class="viewer-body">
+    {#if fileTree.isOpen && diffMetadata}
+      <FileTree
+        entries={fileEntries}
+        currentIndex={contentTracking.currentFileIndex}
+        onJump={jumpToFile}
+      />
+    {/if}
+
     <div
       class="content"
       class:shift-held={interaction.isShiftHeld}
@@ -826,6 +852,7 @@
       {/each}
       </div>
     </div>
+  </div>
 
   <!-- Footer / Status Bar -->
   <div style:zoom={contentZoom}>
@@ -843,6 +870,7 @@
   <CommandPalette
     {tags}
     exitModes={exitModeState.modes}
+    files={fileEntries}
     zoomLevel={contentZoom}
     onClose={handleCommandPaletteClose}
     onSetExitMode={handleSetExitModeFromPalette}

--- a/src/styles/components/code-viewer.css
+++ b/src/styles/components/code-viewer.css
@@ -112,6 +112,7 @@ header.header {
 /* Main content area */
 .content {
 	flex: 1;
+	min-width: 0; /* shrink instead of overflowing when the file tree is open */
 	overflow: auto;
 	padding-bottom: 1rem;
 }

--- a/src/styles/components/file-tree.css
+++ b/src/styles/components/file-tree.css
@@ -1,0 +1,103 @@
+/* ===========================================
+   FILE TREE - Changed-files sidebar (diff mode)
+   =========================================== */
+
+/* Row holding the sidebar and the scrollable content side by side */
+.viewer-body {
+	flex: 1;
+	display: flex;
+	min-height: 0;
+}
+
+.file-tree {
+	flex: 0 0 240px;
+	display: flex;
+	flex-direction: column;
+	min-width: 0;
+	overflow-y: auto;
+	background: var(--bg-panel);
+	border-right: 1px solid var(--border-subtle);
+	font-family: var(--font-ui);
+	font-size: 12px;
+}
+
+.file-tree-summary {
+	display: flex;
+	align-items: center;
+	justify-content: space-between;
+	gap: 8px;
+	padding: 8px 12px;
+	color: var(--text-secondary);
+	border-bottom: 1px solid var(--border-subtle);
+}
+
+.file-tree-list {
+	list-style: none;
+	margin: 0;
+	padding: 4px 0;
+}
+
+.file-row {
+	display: flex;
+	align-items: baseline;
+	justify-content: space-between;
+	gap: 8px;
+	width: 100%;
+	padding: 4px 12px;
+	background: transparent;
+	border: none;
+	border-left: 2px solid transparent;
+	color: var(--text-primary);
+	font: inherit;
+	text-align: left;
+	cursor: pointer;
+}
+
+.file-row:hover {
+	background: var(--bg-hover);
+}
+
+.file-row:focus-visible {
+	outline: none;
+	border-left-color: var(--focus-ring);
+}
+
+.file-row.current {
+	background: var(--accent-bg);
+	border-left-color: var(--accent);
+}
+
+/* The directory prefix absorbs truncation so the basename stays readable. */
+.file-row-path {
+	display: flex;
+	min-width: 0;
+	white-space: nowrap;
+}
+
+.file-row-dir {
+	min-width: 0;
+	overflow: hidden;
+	text-overflow: ellipsis;
+	color: var(--text-muted);
+}
+
+.file-row-name {
+	flex-shrink: 0;
+	font-weight: 600;
+}
+
+.file-tree-counts {
+	display: flex;
+	gap: 6px;
+	flex-shrink: 0;
+	font-family: var(--font-mono);
+	font-size: 11px;
+}
+
+.file-tree-counts .added {
+	color: rgb(34, 197, 94);
+}
+
+.file-tree-counts .deleted {
+	color: rgb(239, 68, 68);
+}

--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -20,6 +20,7 @@
 /* Components */
 @import './components/kbd.css';
 @import './components/code-viewer.css';
+@import './components/file-tree.css';
 @import './components/status-bar.css';
 @import './components/chips.css';
 @import './components/annotation-editor.css';


### PR DESCRIPTION
`Cmd`/`Ctrl+B` toggles a sidebar listing every changed file in a diff with its +/- counts. Clicking a file scrolls to it; the row for the file currently in view stays highlighted. The `:` palette gains a Files namespace that does the same jump by fuzzy search, hidden outside diff sessions.

Also fixes current-file tracking: `useContentTracking` derived the current file from hunk boundaries alone, but a file's header lines sit above its first hunk, so any header line resolved to the *previous* file - visible in the Header breadcrumb when scrolling a file header to the top of the viewport. A separate file-only `ContentTracker` now resolves `currentFileIndex`. `hunkTracker` is left hunk-only because `useSelectionBounds` walks its boundaries pairwise to clamp selections to a hunk.
