### PR TITLE
feat: review git changes from the CLI with `annot diff`

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,9 @@ Claude now has review tools (`review_file`, `review_diff`, `review_content`). As
 ```bash
 annot file.rs           # Open a file for annotation
 annot --json file.rs    # Output as JSON (for agent consumption)
+annot diff              # Review working-tree changes vs HEAD
+annot diff --staged     # Review staged changes
+annot diff main..HEAD   # Review a revision range (main...HEAD for merge base)
 ```
 
 ## How it works

--- a/docs/features.md
+++ b/docs/features.md
@@ -23,7 +23,9 @@ annot is a **structured dialogue medium** — a space where human and AI take tu
 Open any source file for annotation. Syntax highlighting adapts to language. Navigate by line numbers.
 
 ### Diff Review
-Review git changes (`--staged`, `main...HEAD`) or raw unified diffs. Color-coded: additions green, deletions red. Annotations capture both old and new line numbers.
+Review git changes or raw unified diffs. Color-coded: additions green, deletions red. Annotations capture both old and new line numbers.
+
+Git targets work from the CLI (`annot diff`, `annot diff --staged`, `annot diff main..HEAD -- src/`) and from MCP (`review_diff` with `target`/`pathspecs`) — same three comparisons: working tree vs HEAD, index vs HEAD, revision range (`...` diffs from the merge base). Raw diffs come via stdin (`git diff | annot`) or MCP `diff_content`.
 
 **File tree** — `Cmd+B` toggles a sidebar listing every changed file with its +/− counts. Clicking a file scrolls to it (expanding it if collapsed); the row for the file currently in view stays highlighted. The `:` palette's **Files** namespace does the same jump by fuzzy search.
 

--- a/src-tauri/src/input.rs
+++ b/src-tauri/src/input.rs
@@ -55,6 +55,9 @@ pub enum CliSource {
     File { path: PathBuf },
     /// Piped from stdin with user-provided label.
     Stdin { label: String },
+    /// `annot diff` subcommand — git diff from a structured target,
+    /// the CLI twin of `McpSource::Diff` with `DiffSource::Target`.
+    Diff { label: String },
 }
 
 /// MCP content source (which tool was called).
@@ -101,6 +104,7 @@ impl ContentSource {
             ContentSource::Cli(CliSource::File { path })
             | ContentSource::Mcp(McpSource::File { path }) => path.to_str().unwrap_or("file"),
             ContentSource::Cli(CliSource::Stdin { label })
+            | ContentSource::Cli(CliSource::Diff { label })
             | ContentSource::Mcp(McpSource::Content { label }) => label,
             ContentSource::Mcp(McpSource::Diff { label, .. }) => label.as_deref().unwrap_or("diff"),
         }
@@ -112,6 +116,7 @@ impl ContentSource {
             ContentSource::Cli(CliSource::File { path })
             | ContentSource::Mcp(McpSource::File { path }) => path.to_str(),
             ContentSource::Cli(CliSource::Stdin { label })
+            | ContentSource::Cli(CliSource::Diff { label })
             | ContentSource::Mcp(McpSource::Content { label }) => Some(label),
             ContentSource::Mcp(McpSource::Diff { label, .. }) => label.as_deref(),
         }
@@ -141,10 +146,57 @@ impl ContentSource {
             | ContentSource::Mcp(McpSource::File { path }) => FileKey::path(path.clone()),
             ContentSource::Cli(CliSource::Stdin { label }) => FileKey::ephemeral(label.clone()),
             ContentSource::Mcp(McpSource::Content { label }) => FileKey::ephemeral(label.clone()),
-            ContentSource::Mcp(McpSource::Diff { .. }) => {
+            ContentSource::Cli(CliSource::Diff { .. })
+            | ContentSource::Mcp(McpSource::Diff { .. }) => {
                 // Diff mode uses DiffFile keys per file, not a single key for the whole diff
                 unreachable!("Diff mode uses DiffFile keys per file")
             }
+        }
+    }
+}
+
+/// Parse `annot diff`'s CLI arguments into a `DiffTarget` — the same three
+/// comparisons the MCP `review_diff` tool accepts, in git's range syntax:
+/// `A..B` (tree vs tree), `A...B` (merge base vs B), an empty side
+/// defaulting to `HEAD` (git parity: `main..` ≡ `main..HEAD`). A bare
+/// revision is rejected: git's `git diff A` means worktree-vs-A, a
+/// comparison the target model deliberately doesn't express.
+pub fn parse_diff_target(
+    range: Option<&str>,
+    staged: bool,
+) -> Result<crate::vcs::DiffTarget, AnnotError> {
+    use crate::vcs::DiffTarget;
+
+    match (range, staged) {
+        (Some(_), true) => Err(AnnotError::Validation(
+            "--staged cannot be combined with a revision range".into(),
+        )),
+        (None, true) => Ok(DiffTarget::Staged),
+        (None, false) => Ok(DiffTarget::WorkingTree),
+        (Some(spec), false) => {
+            let (separator, merge_base) = if spec.contains("...") {
+                ("...", true)
+            } else if spec.contains("..") {
+                ("..", false)
+            } else {
+                return Err(AnnotError::Validation(format!(
+                    "unsupported range '{spec}': use '{spec}..HEAD' (changes since {spec}) \
+                     or '{spec}...HEAD' (changes since the merge base)"
+                )));
+            };
+            let (from, to) = spec.split_once(separator).expect("separator just matched");
+            let default_head = |side: &str| {
+                if side.is_empty() {
+                    "HEAD".to_string()
+                } else {
+                    side.to_string()
+                }
+            };
+            Ok(DiffTarget::Range {
+                from: default_head(from),
+                to: default_head(to),
+                merge_base,
+            })
         }
     }
 }
@@ -345,6 +397,59 @@ mod tests {
         let resolved = mode.resolve().unwrap();
 
         assert_eq!(resolved.rendering_mode, RenderingMode::Diff);
+    }
+
+    #[test]
+    fn parse_diff_target_covers_all_mcp_shapes() {
+        use crate::vcs::DiffTarget;
+
+        assert_eq!(
+            parse_diff_target(None, false).unwrap(),
+            DiffTarget::WorkingTree
+        );
+        assert_eq!(parse_diff_target(None, true).unwrap(), DiffTarget::Staged);
+        assert_eq!(
+            parse_diff_target(Some("main..HEAD"), false).unwrap(),
+            DiffTarget::Range {
+                from: "main".into(),
+                to: "HEAD".into(),
+                merge_base: false,
+            }
+        );
+        assert_eq!(
+            parse_diff_target(Some("main...feature"), false).unwrap(),
+            DiffTarget::Range {
+                from: "main".into(),
+                to: "feature".into(),
+                merge_base: true,
+            }
+        );
+        // git parity: an empty side means HEAD
+        assert_eq!(
+            parse_diff_target(Some("main.."), false).unwrap(),
+            DiffTarget::Range {
+                from: "main".into(),
+                to: "HEAD".into(),
+                merge_base: false,
+            }
+        );
+        assert_eq!(
+            parse_diff_target(Some("...feature"), false).unwrap(),
+            DiffTarget::Range {
+                from: "HEAD".into(),
+                to: "feature".into(),
+                merge_base: true,
+            }
+        );
+    }
+
+    #[test]
+    fn parse_diff_target_rejects_bare_revisions_with_a_hint() {
+        let err = parse_diff_target(Some("main"), false).unwrap_err();
+        assert!(err.to_string().contains("main..HEAD"));
+
+        let err = parse_diff_target(Some("main..HEAD"), true).unwrap_err();
+        assert!(err.to_string().contains("--staged"));
     }
 
     #[test]

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -6,7 +6,7 @@ use std::process;
 
 use clap::Parser;
 
-use annot_lib::input::{InputMode, RenderingMode};
+use annot_lib::input::{CliSource, ContentSource, InputMode, RenderingMode};
 use annot_lib::state::AppState;
 
 const EXAMPLES: &str = "\
@@ -16,6 +16,9 @@ Examples:
   annot document.md              # Open file for annotation
   cat file.go | annot            # Pipe content from stdin
   cat file.go | annot -l main.go # Pipe with label (for syntax highlighting)
+  annot diff                     # Review working-tree changes vs HEAD
+  annot diff --staged            # Review staged changes
+  annot diff main..HEAD -- src/  # Review a revision range, limited to src/
   annot mcp                      # Run as MCP server";
 
 #[derive(Parser)]
@@ -36,22 +39,44 @@ struct Cli {
     label: String,
 
     /// Output annotations as JSON (includes base64 images)
-    #[arg(long)]
+    #[arg(long, global = true)]
     json: bool,
 
     /// Add an exit mode button: "name:instruction" (repeatable)
     ///
     /// Example: --exit-mode "Apply:Apply the changes" --exit-mode "Reject:Discard"
-    #[arg(long = "exit-mode", value_name = "NAME:INSTRUCTION")]
+    #[arg(long = "exit-mode", value_name = "NAME:INSTRUCTION", global = true)]
     exit_modes: Vec<String>,
 }
 
 #[derive(clap::Subcommand)]
 enum Command {
+    /// Review git changes (CLI parity with the MCP review_diff tool)
+    Diff(DiffArgs),
     /// Run as MCP server (Model Context Protocol)
     Mcp,
     /// Print version information
     Version,
+}
+
+#[derive(clap::Args)]
+struct DiffArgs {
+    /// Revision range: A..B, or A...B to diff from the merge base
+    /// (an empty side means HEAD, e.g. "main..")
+    #[arg(value_name = "RANGE", conflicts_with = "staged")]
+    range: Option<String>,
+
+    /// Review staged changes (index vs HEAD)
+    #[arg(long)]
+    staged: bool,
+
+    /// Display label (default: derived from the target)
+    #[arg(short = 'l', long = "label")]
+    label: Option<String>,
+
+    /// Git pathspecs limiting the diff, after "--" (e.g. -- src/ '*.rs')
+    #[arg(last = true, value_name = "PATHSPEC")]
+    pathspecs: Vec<String>,
 }
 
 fn main() {
@@ -75,29 +100,6 @@ fn main() {
         annot_lib::run_mcp(context);
         return;
     }
-
-    // Detect input mode from CLI args and stdin state
-    let (mode, warning) = match InputMode::detect(cli.file, cli.label) {
-        Ok(result) => result,
-        Err(e) => {
-            eprintln!("{}", e);
-            process::exit(1);
-        }
-    };
-
-    // Print warning if both stdin and file were provided
-    if let Some(warning) = warning {
-        eprintln!("{}", warning);
-    }
-
-    // Resolve content from the input mode (reads file/stdin)
-    let input = match mode.resolve() {
-        Ok(input) => input,
-        Err(e) => {
-            eprintln!("{}", e);
-            process::exit(1);
-        }
-    };
 
     // Load config
     let mut config = annot_lib::state::UserConfig::load();
@@ -126,8 +128,71 @@ fn main() {
         config.prepend_transient_modes(transient_modes);
     }
 
-    // Create content model based on rendering mode
-    let content = match input.rendering_mode {
+    // Resolve content: the diff subcommand renders via the git pipeline;
+    // everything else reads file/stdin and detects a rendering mode.
+    let content = match cli.command {
+        Some(Command::Diff(args)) => git_diff_content(args),
+        _ => cli_input_content(cli.file, cli.label),
+    };
+
+    let state = AppState::new(content, config);
+
+    annot_lib::run(state, context, cli.json);
+}
+
+/// `annot diff`: render a structured git target through the pipeline — the
+/// CLI twin of the MCP `review_diff` tool (same targets, same cwd semantics).
+fn git_diff_content(args: DiffArgs) -> annot_lib::state::ContentModel {
+    let target = match annot_lib::input::parse_diff_target(args.range.as_deref(), args.staged) {
+        Ok(target) => target,
+        Err(e) => {
+            eprintln!("{}", e);
+            process::exit(1);
+        }
+    };
+    let cwd = match std::env::current_dir() {
+        Ok(cwd) => cwd,
+        Err(e) => {
+            eprintln!("Failed to resolve working directory: {}", e);
+            process::exit(1);
+        }
+    };
+    let label = args.label.unwrap_or_else(|| target.label());
+    let source = ContentSource::Cli(CliSource::Diff { label });
+    match annot_lib::state::ContentModel::from_git(&cwd, &target, &args.pathspecs, source) {
+        Ok(content) => content,
+        Err(e) => {
+            eprintln!("{}", e);
+            process::exit(1);
+        }
+    }
+}
+
+/// File-or-stdin input: detect the mode, read the content, pick a renderer.
+fn cli_input_content(file: Option<PathBuf>, label: String) -> annot_lib::state::ContentModel {
+    let (mode, warning) = match InputMode::detect(file, label) {
+        Ok(result) => result,
+        Err(e) => {
+            eprintln!("{}", e);
+            process::exit(1);
+        }
+    };
+
+    // Print warning if both stdin and file were provided
+    if let Some(warning) = warning {
+        eprintln!("{}", warning);
+    }
+
+    // Resolve content from the input mode (reads file/stdin)
+    let input = match mode.resolve() {
+        Ok(input) => input,
+        Err(e) => {
+            eprintln!("{}", e);
+            process::exit(1);
+        }
+    };
+
+    match input.rendering_mode {
         RenderingMode::Diff => {
             match annot_lib::state::ContentModel::from_diff(&input.content, input.content_source) {
                 Ok(content) => content,
@@ -143,9 +208,5 @@ fn main() {
         RenderingMode::Source => {
             annot_lib::state::ContentModel::from_file(&input.content, input.content_source)
         }
-    };
-
-    let state = AppState::new(content, config);
-
-    annot_lib::run(state, context, cli.json);
+    }
 }


### PR DESCRIPTION
CLI parity with the MCP review_diff tool's git targets: `annot diff` (working tree vs HEAD), `annot diff --staged` (index vs HEAD), and `annot diff A..B` / `A...B` ranges (three-dot diffs from the merge base; an empty side means HEAD, matching git). Pathspecs go after `--`. Since these render through the git pipeline, unfold gap bars work — unlike piped patch text, which has no file contents to slice.

Engineering notes: `--json` and `--exit-mode` became global clap args so they compose with subcommands. Range parsing lives in input::parse_diff_target (unit-tested); a bare revision is rejected with a hint because worktree-vs-rev isn't expressible in DiffTarget — the same deliberate boundary the MCP tool has. New CliSource::Diff mirrors McpSource::Diff so session identity/output stay CLI-shaped.